### PR TITLE
Duration is added between the messaging between node and processor scheduler

### DIFF
--- a/qoala/lang/ehi.py
+++ b/qoala/lang/ehi.py
@@ -36,10 +36,11 @@ class EhiLatencies:
     host_instr_time: float  # duration of classical Host instr execution (CL)
     qnos_instr_time: float  # duration of classical Qnos instr execution (QL)
     host_peer_latency: float  # processing time for Host messages from remote node (CC)
+    internal_sched_latency: float  # processing time for messaging between node scheduler and processor schedulers
 
     @classmethod
     def all_zero(cls) -> EhiLatencies:
-        return EhiLatencies(0, 0, 0)
+        return EhiLatencies(0, 0, 0, 0)
 
 
 @dataclass(frozen=True)

--- a/qoala/runtime/config.py
+++ b/qoala/runtime/config.py
@@ -1215,6 +1215,7 @@ class LatenciesConfig(BaseModel, LhiLatenciesConfigInterface):
     host_instr_time: float = 0.0  # duration of classical Host instr execution
     qnos_instr_time: float = 0.0  # duration of classical Qnos instr execution
     host_peer_latency: float = 0.0  # processing time for Host messages from remote node
+    internal_sched_latency: float = 0  # processing time for messaging between node scheduler and processor schedulers
 
     @classmethod
     def from_file(cls, path: str) -> LatenciesConfig:
@@ -1231,10 +1232,14 @@ class LatenciesConfig(BaseModel, LhiLatenciesConfigInterface):
         host_peer_latency = 0.0
         if "host_peer_latency" in dict:
             host_peer_latency = dict["host_peer_latency"]
+        internal_sched_latency = 0.0
+        if "internal_sched_latency" in dict:
+            host_peer_latency = dict["internal_sched_latency"]
         return LatenciesConfig(
             host_instr_time=host_instr_time,
             qnos_instr_time=qnos_instr_time,
             host_peer_latency=host_peer_latency,
+            internal_sched_latency=internal_sched_latency,
         )
 
     def get_host_instr_time(self) -> float:
@@ -1245,6 +1250,9 @@ class LatenciesConfig(BaseModel, LhiLatenciesConfigInterface):
 
     def get_host_peer_latency(self) -> float:
         return self.host_peer_latency
+
+    def get_internal_sched_latency(self) -> float:
+        return self.internal_sched_latency
 
 
 class ProcNodeConfig(BaseModel):

--- a/qoala/runtime/lhi.py
+++ b/qoala/runtime/lhi.py
@@ -366,12 +366,16 @@ class LhiLatenciesConfigInterface(ABC):
     def get_host_peer_latency(self) -> float:
         raise NotImplementedError
 
+    def get_internal_sched_latency(self):
+        raise NotImplementedError
+
 
 @dataclass
 class LhiLatencies:
     host_instr_time: float = 0  # duration of classical Host instr execution
     qnos_instr_time: float = 0  # duration of classical Qnos instr execution
     host_peer_latency: float = 0  # processing time for Host messages from remote node
+    internal_sched_latency: float = 0  # processing time for messaging between node scheduler and processor schedulers
 
     @classmethod
     def from_config(cls, cfg: LhiLatenciesConfigInterface) -> LhiLatencies:
@@ -379,13 +383,14 @@ class LhiLatencies:
             host_instr_time=cfg.get_host_instr_time(),
             qnos_instr_time=cfg.get_qnos_instr_time(),
             host_peer_latency=cfg.get_host_peer_latency(),
+            internal_sched_latency=cfg.get_internal_sched_latency(),
         )
 
     @classmethod
     def all_zero(cls) -> LhiLatencies:
         # NOTE: can also just use LhiLatencies() which will default all values to 0
         # However, using this classmethod makes this behavior more explicit and clear.
-        return LhiLatencies(0, 0, 0)
+        return LhiLatencies(0, 0, 0, 0)
 
 
 class LhiLinkConfigInterface(ABC):

--- a/qoala/runtime/lhi_to_ehi.py
+++ b/qoala/runtime/lhi_to_ehi.py
@@ -93,6 +93,7 @@ class LhiConverter:
             latencies.host_instr_time,
             latencies.qnos_instr_time,
             latencies.host_peer_latency,
+            latencies.internal_sched_latency,
         )
 
         return EhiNodeInfo(

--- a/tests/test_internal_sched_latency.iqoala
+++ b/tests/test_internal_sched_latency.iqoala
@@ -1,0 +1,14 @@
+META_START
+    name: alice
+    parameters:
+    csockets:
+    epr_sockets:
+META_END
+
+^blk1 {type = CL}:
+    var_x = assign_cval() : 0
+    var_y = assign_cval() : 1
+
+^blk2 {type = CL}:
+    var_x = assign_cval() : 2
+    var_y = assign_cval() : 3


### PR DESCRIPTION
- `internal_sched_latency` is added to `LhiLatencies`, `EhiLatencies` and `LatenciesConfig`.
- Added `ClassicalChannel` to `NodeSchedulerComponent` with delay specified with `internal_sched_latency`.
- To make `Processor Scheduler`s wait for the message in the initialization of the `Node Scheduler`, their order in the `start` method is reversed.
- Simple test is added.