### PR TITLE
Adding Vector Indexing

### DIFF
--- a/qoala/lang/hostlang.py
+++ b/qoala/lang/hostlang.py
@@ -21,11 +21,6 @@ class IqoalaInstructionType(Enum):
 
 
 @dataclass(frozen=True)
-class IqoalaAttribute:
-    value: IqoalaValue
-
-
-@dataclass(frozen=True)
 class IqoalaTuple:
     values: List[str]
 
@@ -38,10 +33,16 @@ class IqoalaVector:
     # TODO: create single IqoalaVar class that IqoalaVector, IqoalaTuple,
     # and IqoalaSingleton derive from
     name: str
-    size: Union[int, str]
+    size: IqoalaValue
 
     def __str__(self) -> str:
         return f"{self.name}<{self.size}>"
+
+
+@dataclass(frozen=True)
+class IqoalaVectorElement:
+    vector_name: str
+    index: int
 
 
 class ClassicalIqoalaOp:

--- a/qoala/lang/hostlang.py
+++ b/qoala/lang/hostlang.py
@@ -550,7 +550,7 @@ class ReturnResultOp(ClassicalIqoalaOp):
     OP_NAME = "return_result"
     TYP = IqoalaInstructionType.CL
 
-    def __init__(self, value: IqoalaSingleton) -> None:
+    def __init__(self, value: Union[IqoalaSingleton, IqoalaVector]) -> None:
         super().__init__(arguments=[value])
 
     @classmethod
@@ -572,9 +572,11 @@ class ReturnResultOp(ClassicalIqoalaOp):
             raise HostLanguageSyntaxError(
                 f"{cls.OP_NAME} operation cannot have an attribute."
             )
-        if not isinstance(args[0], IqoalaSingleton):
+        if not isinstance(args[0], IqoalaSingleton) and not isinstance(
+            args[0], IqoalaVector
+        ):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation arguments must be string."
+                f"{cls.OP_NAME} operation argument must be a string or vector."
             )
 
         return cls(args[0])

--- a/qoala/lang/hostlang.py
+++ b/qoala/lang/hostlang.py
@@ -51,7 +51,7 @@ class IqoalaVector(IqoalaVar):
 
 @dataclass(frozen=True)
 class IqoalaVectorElement(IqoalaVar):
-    vector_name: str
+    name: str
     index: int
 
 
@@ -203,7 +203,11 @@ class SendCMsgOp(ClassicalIqoalaOp):
     OP_NAME = "send_cmsg"
     TYP = IqoalaInstructionType.CC
 
-    def __init__(self, csocket: IqoalaSingleton, value: IqoalaSingleton) -> None:
+    def __init__(
+        self,
+        csocket: Union[IqoalaSingleton, IqoalaVectorElement],
+        value: Union[IqoalaSingleton, IqoalaVectorElement],
+    ) -> None:
         # args:
         #   csocket (int): ID of csocket
         #   value (str): name of variable holding the value to send
@@ -228,11 +232,15 @@ class SendCMsgOp(ClassicalIqoalaOp):
             raise HostLanguageSyntaxError(
                 f"{cls.OP_NAME} operation cannot have an attribute."
             )
-        if not isinstance(args[0], IqoalaSingleton) or not isinstance(
-            args[1], IqoalaSingleton
+        if (
+            not isinstance(args[0], IqoalaSingleton)
+            and not isinstance(args[0], IqoalaVectorElement)
+        ) or (
+            not isinstance(args[1], IqoalaSingleton)
+            and not isinstance(args[1], IqoalaVectorElement)
         ):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation arguments must be strings."
+                f"{cls.OP_NAME} operation arguments must be strings or vector elements."
             )
         return cls(args[0], args[1])
 
@@ -241,7 +249,11 @@ class ReceiveCMsgOp(ClassicalIqoalaOp):
     OP_NAME = "recv_cmsg"
     TYP = IqoalaInstructionType.CC
 
-    def __init__(self, csocket: IqoalaSingleton, result: IqoalaSingleton) -> None:
+    def __init__(
+        self,
+        csocket: Union[IqoalaSingleton, IqoalaVectorElement],
+        result: IqoalaSingleton,
+    ) -> None:
         super().__init__(arguments=[csocket], results=result)
 
     @classmethod
@@ -265,9 +277,11 @@ class ReceiveCMsgOp(ClassicalIqoalaOp):
             raise HostLanguageSyntaxError(
                 f"{cls.OP_NAME} operation cannot have an attribute."
             )
-        if not isinstance(args[0], IqoalaSingleton):
+        if not isinstance(args[0], IqoalaSingleton) and not isinstance(
+            args[0], IqoalaVectorElement
+        ):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation argument must be a string."
+                f"{cls.OP_NAME} operation arguments must be strings or vector elements."
             )
         return cls(args[0], result)
 
@@ -277,7 +291,10 @@ class AddCValueOp(ClassicalIqoalaOp):
     TYP = IqoalaInstructionType.CL
 
     def __init__(
-        self, result: IqoalaSingleton, value0: IqoalaSingleton, value1: IqoalaSingleton
+        self,
+        result: IqoalaSingleton,
+        value0: Union[IqoalaSingleton, IqoalaVectorElement],
+        value1: Union[IqoalaSingleton, IqoalaVectorElement],
     ) -> None:
         super().__init__(arguments=[value0, value1], results=result)
 
@@ -302,11 +319,15 @@ class AddCValueOp(ClassicalIqoalaOp):
             raise HostLanguageSyntaxError(
                 f"{cls.OP_NAME} operation cannot have an attribute."
             )
-        if not isinstance(args[0], IqoalaSingleton) or not isinstance(
-            args[1], IqoalaSingleton
+        if (
+            not isinstance(args[0], IqoalaSingleton)
+            and not isinstance(args[0], IqoalaVectorElement)
+        ) or (
+            not isinstance(args[1], IqoalaSingleton)
+            and not isinstance(args[1], IqoalaVectorElement)
         ):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation arguments must be strings."
+                f"{cls.OP_NAME} operation arguments must be strings or vector elements."
             )
         return cls(result, args[0], args[1])
 
@@ -316,7 +337,10 @@ class MultiplyConstantCValueOp(ClassicalIqoalaOp):
     TYP = IqoalaInstructionType.CL
 
     def __init__(
-        self, result: IqoalaSingleton, value0: IqoalaSingleton, const: IqoalaValue
+        self,
+        result: IqoalaSingleton,
+        value0: Union[IqoalaSingleton, IqoalaVectorElement],
+        const: IqoalaValue,
     ) -> None:
         # result = value0 * const
         super().__init__(arguments=[value0], attributes=[const], results=result)
@@ -342,9 +366,11 @@ class MultiplyConstantCValueOp(ClassicalIqoalaOp):
             raise HostLanguageSyntaxError(
                 f"{cls.OP_NAME} operation must have an attribute."
             )
-        if not isinstance(args[0], IqoalaSingleton):
+        if not isinstance(args[0], IqoalaSingleton) and not isinstance(
+            args[0], IqoalaVectorElement
+        ):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation arguments must be a string."
+                f"{cls.OP_NAME} operation arguments must be strings or vector elements."
             )
         return cls(result, args[0], attr)
 
@@ -356,8 +382,8 @@ class BitConditionalMultiplyConstantCValueOp(ClassicalIqoalaOp):
     def __init__(
         self,
         result: IqoalaSingleton,
-        value0: IqoalaSingleton,
-        cond: IqoalaSingleton,
+        value0: Union[IqoalaSingleton, IqoalaVectorElement],
+        cond: Union[IqoalaSingleton, IqoalaVectorElement],
         const: int,
     ) -> None:
         # if const == 1:
@@ -387,11 +413,15 @@ class BitConditionalMultiplyConstantCValueOp(ClassicalIqoalaOp):
             raise HostLanguageSyntaxError(
                 f"{cls.OP_NAME} operation must have an attribute."
             )
-        if not isinstance(args[0], IqoalaSingleton) or not isinstance(
-            args[1], IqoalaSingleton
+        if (
+            not isinstance(args[0], IqoalaSingleton)
+            and not isinstance(args[0], IqoalaVectorElement)
+        ) or (
+            not isinstance(args[1], IqoalaSingleton)
+            and not isinstance(args[1], IqoalaVectorElement)
         ):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation arguments must be strings."
+                f"{cls.OP_NAME} operation arguments must be strings or vector elements."
             )
         if not isinstance(attr, int):
             raise HostLanguageSyntaxError(
@@ -544,7 +574,7 @@ class ReturnResultOp(ClassicalIqoalaOp):
             )
         if not isinstance(args[0], IqoalaSingleton):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation argument must be a string."
+                f"{cls.OP_NAME} operation arguments must be string."
             )
 
         return cls(args[0])
@@ -588,7 +618,10 @@ class BranchIfEqualOp(ClassicalIqoalaOp):
     TYP = IqoalaInstructionType.CL
 
     def __init__(
-        self, value0: IqoalaSingleton, value1: IqoalaSingleton, block_name: str
+        self,
+        value0: Union[IqoalaSingleton, IqoalaVectorElement],
+        value1: Union[IqoalaSingleton, IqoalaVectorElement],
+        block_name: str,
     ) -> None:
         super().__init__(arguments=[value0, value1], attributes=[block_name])
 
@@ -615,11 +648,15 @@ class BranchIfEqualOp(ClassicalIqoalaOp):
             raise HostLanguageSyntaxError(
                 f"{cls.OP_NAME} operation attribute must be a string."
             )
-        if not isinstance(args[0], IqoalaSingleton) or not isinstance(
-            args[1], IqoalaSingleton
+        if (
+            not isinstance(args[0], IqoalaSingleton)
+            and not isinstance(args[0], IqoalaVectorElement)
+        ) or (
+            not isinstance(args[1], IqoalaSingleton)
+            and not isinstance(args[1], IqoalaVectorElement)
         ):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation arguments must be strings."
+                f"{cls.OP_NAME} operation arguments must be strings or vector elements."
             )
 
         return cls(args[0], args[1], attr)
@@ -630,7 +667,10 @@ class BranchIfNotEqualOp(ClassicalIqoalaOp):
     TYP = IqoalaInstructionType.CL
 
     def __init__(
-        self, value0: IqoalaSingleton, value1: IqoalaSingleton, block_name: str
+        self,
+        value0: Union[IqoalaSingleton, IqoalaVectorElement],
+        value1: Union[IqoalaSingleton, IqoalaVectorElement],
+        block_name: str,
     ) -> None:
         super().__init__(arguments=[value0, value1], attributes=[block_name])
 
@@ -657,11 +697,15 @@ class BranchIfNotEqualOp(ClassicalIqoalaOp):
             raise HostLanguageSyntaxError(
                 f"{cls.OP_NAME} operation attribute must be a string."
             )
-        if not isinstance(args[0], IqoalaSingleton) or not isinstance(
-            args[1], IqoalaSingleton
+        if (
+            not isinstance(args[0], IqoalaSingleton)
+            and not isinstance(args[0], IqoalaVectorElement)
+        ) or (
+            not isinstance(args[1], IqoalaSingleton)
+            and not isinstance(args[1], IqoalaVectorElement)
         ):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation arguments must be strings."
+                f"{cls.OP_NAME} operation arguments must be strings or vector elements."
             )
         return cls(args[0], args[1], attr)
 
@@ -671,7 +715,10 @@ class BranchIfGreaterThanOp(ClassicalIqoalaOp):
     TYP = IqoalaInstructionType.CL
 
     def __init__(
-        self, value0: IqoalaSingleton, value1: IqoalaSingleton, block_name: str
+        self,
+        value0: Union[IqoalaSingleton, IqoalaVectorElement],
+        value1: Union[IqoalaSingleton, IqoalaVectorElement],
+        block_name: str,
     ) -> None:
         super().__init__(arguments=[value0, value1], attributes=[block_name])
 
@@ -698,11 +745,15 @@ class BranchIfGreaterThanOp(ClassicalIqoalaOp):
             raise HostLanguageSyntaxError(
                 f"{cls.OP_NAME} operation attribute must be a string."
             )
-        if not isinstance(args[0], IqoalaSingleton) or not isinstance(
-            args[1], IqoalaSingleton
+        if (
+            not isinstance(args[0], IqoalaSingleton)
+            and not isinstance(args[0], IqoalaVectorElement)
+        ) or (
+            not isinstance(args[1], IqoalaSingleton)
+            and not isinstance(args[1], IqoalaVectorElement)
         ):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation arguments must be strings."
+                f"{cls.OP_NAME} operation arguments must be strings or vector elements."
             )
         return cls(args[0], args[1], attr)
 
@@ -712,7 +763,10 @@ class BranchIfLessThanOp(ClassicalIqoalaOp):
     TYP = IqoalaInstructionType.CL
 
     def __init__(
-        self, value0: IqoalaSingleton, value1: IqoalaSingleton, block_name: str
+        self,
+        value0: Union[IqoalaSingleton, IqoalaVectorElement],
+        value1: Union[IqoalaSingleton, IqoalaVectorElement],
+        block_name: str,
     ) -> None:
         super().__init__(arguments=[value0, value1], attributes=[block_name])
 
@@ -739,11 +793,15 @@ class BranchIfLessThanOp(ClassicalIqoalaOp):
             raise HostLanguageSyntaxError(
                 f"{cls.OP_NAME} operation attribute must be a string."
             )
-        if not isinstance(args[0], IqoalaSingleton) or not isinstance(
-            args[1], IqoalaSingleton
+        if (
+            not isinstance(args[0], IqoalaSingleton)
+            and not isinstance(args[0], IqoalaVectorElement)
+        ) or (
+            not isinstance(args[1], IqoalaSingleton)
+            and not isinstance(args[1], IqoalaVectorElement)
         ):
             raise HostLanguageSyntaxError(
-                f"{cls.OP_NAME} operation arguments must be strings."
+                f"{cls.OP_NAME} operation arguments must be strings or vector elements."
             )
         return cls(args[0], args[1], attr)
 

--- a/qoala/lang/hostlang.py
+++ b/qoala/lang/hostlang.py
@@ -117,7 +117,7 @@ class ClassicalIqoalaOp:
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ) -> ClassicalIqoalaOp:
         raise NotImplementedError
@@ -150,7 +150,7 @@ class AssignCValueOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is None:
@@ -260,7 +260,7 @@ class ReceiveCMsgOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is None:
@@ -302,7 +302,7 @@ class AddCValueOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is None:
@@ -349,7 +349,7 @@ class MultiplyConstantCValueOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is None:
@@ -396,7 +396,7 @@ class BitConditionalMultiplyConstantCValueOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is None:
@@ -446,7 +446,7 @@ class RunSubroutineOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is not None:
@@ -504,7 +504,7 @@ class RunRequestOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is not None:
@@ -557,7 +557,7 @@ class ReturnResultOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is not None:
@@ -593,7 +593,7 @@ class JumpOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is not None:
@@ -631,7 +631,7 @@ class BranchIfEqualOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is not None:
@@ -680,7 +680,7 @@ class BranchIfNotEqualOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is not None:
@@ -728,7 +728,7 @@ class BranchIfGreaterThanOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is not None:
@@ -776,7 +776,7 @@ class BranchIfLessThanOp(ClassicalIqoalaOp):
     def from_generic_args(
         cls,
         result: Optional[IqoalaVar],
-        args: Union[List[IqoalaVar]],
+        args: List[IqoalaVar],
         attr: Optional[IqoalaValue],
     ):
         if result is not None:

--- a/qoala/lang/parse.py
+++ b/qoala/lang/parse.py
@@ -229,7 +229,29 @@ class IqoalaInstrParser:
                 vec_size = vec_size_str
 
             return hl.IqoalaVector(vec_name, vec_size)
+        elif "[" in var_str:
+            if var_str.startswith("["):
+                raise QoalaParseError("Iqoala vector indexing must start with a name.")
+            if not var_str.endswith("]"):
+                raise QoalaParseError("Iqoala vector indexing must end with a ']'.")
+            if var_str.count("[") != 1 or var_str.count("]") != 1:
+                raise QoalaParseError(
+                    "Iqoala vector indexing must have a single '[' and a single ']'."
+                )
+            vec_split = var_str.split("[")
+            vec_name = vec_split[0]
+            if not is_valid_name(vec_name):
+                raise QoalaParseError(f"Value {vec_name} is not a valid variable name.")
+            index_str = vec_split[1][:-1]  # strip last "]"
+            index: int
+            try:
+                index = int(index_str)
+            except ValueError:
+                raise QoalaParseError("Iqoala vector indexing must be an integer.")
+            return hl.IqoalaVectorElement(vec_name, index)
         else:
+            if not is_valid_name(var_str):
+                raise QoalaParseError(f"Value {var_str} is not a valid variable name.")
             return IqoalaSingleton(var_str)
 
     def _parse_lhr(self) -> hl.ClassicalIqoalaOp:

--- a/qoala/lang/parse.py
+++ b/qoala/lang/parse.py
@@ -7,6 +7,7 @@ from netqasm.lang.operand import Template
 from netqasm.lang.parsing.text import parse_text_subroutine
 
 from qoala.lang import hostlang as hl
+from qoala.lang.hostlang import IqoalaValue, IqoalaVector
 from qoala.lang.program import LocalRoutine, ProgramMeta, QoalaProgram
 from qoala.lang.request import (
     CallbackType,
@@ -15,9 +16,8 @@ from qoala.lang.request import (
     QoalaRequest,
     RequestRoutine,
     RequestVirtIdMapping,
-    RrReturnVector,
 )
-from qoala.lang.routine import LrReturnVector, RoutineMetadata
+from qoala.lang.routine import RoutineMetadata
 
 LHR_OP_NAMES: Dict[str, hl.ClassicalIqoalaOp] = {
     cls.OP_NAME: cls  # type: ignore
@@ -128,14 +128,31 @@ class IqoalaMetaParser:
                 )
             name = name_values[0].strip()
             if not is_valid_name(name):
-                raise QoalaParseError(f"Value {name} is not a valid name.")
+                raise QoalaParseError(
+                    f"Value {name} in Qoala Program Meta is not a valid program name."
+                )
 
             parameters = self._parse_meta_line("parameters", self._read_line())
+            for param in parameters:
+                if not is_valid_name(param):
+                    raise QoalaParseError(
+                        f"Value {param} in Qoala Program Meta is not a valid parameter name."
+                    )
 
             csockets_map = self._parse_meta_line("csockets", self._read_line())
             csockets = self._parse_meta_mapping(csockets_map)
+            for node_name in csockets.values():
+                if not is_valid_name(node_name):
+                    raise QoalaParseError(
+                        f"Value {node_name} in Qoala Program Meta is not a valid remote node name."
+                    )
             epr_sockets_map = self._parse_meta_line("epr_sockets", self._read_line())
             epr_sockets = self._parse_meta_mapping(epr_sockets_map)
+            for node_name in epr_sockets.values():
+                if not is_valid_name(node_name):
+                    raise QoalaParseError(
+                        f"Value {node_name} in Qoala Program Meta is not a valid remote node name."
+                    )
 
             end_line = self._read_line()
             if end_line != "META_END":
@@ -201,11 +218,16 @@ class IqoalaInstrParser:
             if not is_valid_name(vec_name):
                 raise QoalaParseError(f"Value {vec_name} is not a valid variable name.")
             vec_size_str = vec_split[1][:-1]  # strip last ">"
-            vec_size: Union[str, int]
+            vec_size: IqoalaValue  # Template is not used insde the blocks
             try:
                 vec_size = int(vec_size_str)
             except ValueError:
+                if not is_valid_name(vec_size_str):
+                    raise QoalaParseError(
+                        f"Value {vec_size_str} is not a valid variable name."
+                    )
                 vec_size = vec_size_str
+
             return hl.IqoalaVector(vec_name, vec_size)
         else:
             return var_str
@@ -427,7 +449,7 @@ class LocalRoutineParser:
 
     def _parse_subrt_meta_line_with_vecs(
         self, key: str, line: str
-    ) -> List[Union[str, LrReturnVector]]:
+    ) -> List[Union[str, IqoalaVector]]:
         if line.count(":") != 1:
             raise QoalaParseError("SubRoutine Meta lines must have a single colon.")
         split = line.split(":")
@@ -442,7 +464,7 @@ class LocalRoutineParser:
             return []
         values_str = split[1].split(",")
         values_str = [v.strip() for v in values_str]
-        values: List[Union[str, LrReturnVector]] = []
+        values: List[Union[str, IqoalaVector]] = []
         for v in values_str:
             if "<" in v:
                 if v.startswith("<"):
@@ -459,10 +481,28 @@ class LocalRoutineParser:
                     raise QoalaParseError(
                         f"Value {vec_name} is not a valid variable name."
                     )
-                vec_size_str = vec_split[1][:-1]  # strip last ">"
-                vec_size = int(vec_size_str)
-                values.append(LrReturnVector(vec_name, vec_size))
+                vec_size_str = vec_split[1][:-1].strip()  # strip last ">"
+                vec_size: IqoalaValue
+                if vec_size_str.startswith("{") and vec_size_str.endswith("}"):
+                    vec_size_str = vec_size_str.strip("{}").strip()
+                    if not is_valid_name(vec_size_str):
+                        raise QoalaParseError(
+                            f"Value {vec_size_str} is not a valid name for a template. "
+                        )
+
+                    vec_size = Template(vec_size_str)
+                else:
+                    try:
+                        vec_size = int(vec_size_str)
+                    except ValueError:
+                        raise QoalaParseError(
+                            "An integer or a template(using '{' and '{') must be provided "
+                            f"as the size of an Iqoala vector {vec_name}."
+                        )
+                values.append(IqoalaVector(vec_name, vec_size))
             else:
+                if not is_valid_name(v):
+                    raise QoalaParseError(f"Value {v} is not a valid variable name.")
                 values.append(v)
         return values
 
@@ -474,6 +514,11 @@ class LocalRoutineParser:
         if not is_valid_name(name):
             raise QoalaParseError(f"Value {name} is not a valid SubRoutine name.")
         params_line = self._parse_subrt_meta_line("params", self._read_line())
+        for param in params_line:
+            if not is_valid_name(param):
+                raise QoalaParseError(
+                    f"SubRoutine {name}: value {param} is not a valid name for a parameter."
+                )
         # TODO: use params line?
 
         return_vars = self._parse_subrt_meta_line_with_vecs(
@@ -482,9 +527,19 @@ class LocalRoutineParser:
         assert all(" " not in v for v in return_vars if isinstance(v, str))
 
         uses_line = self._parse_subrt_meta_line("uses", self._read_line())
-        uses = [int(u) for u in uses_line]
+        try:
+            uses = [int(u) for u in uses_line]
+        except ValueError:
+            raise QoalaParseError(
+                f"SubRoutine {name}: 'uses' line values must be a comma separated list of integers."
+            )
         keeps_line = self._parse_subrt_meta_line("keeps", self._read_line())
-        keeps = [int(k) for k in keeps_line]
+        try:
+            keeps = [int(k) for k in keeps_line]
+        except ValueError:
+            raise QoalaParseError(
+                f"SubRoutine {name}: 'keeps' line values must be a comma separated list of integers."
+            )
         metadata = RoutineMetadata(qubit_use=uses, qubit_keep=keeps)
 
         request_line = self._parse_subrt_meta_line("request", self._read_line())
@@ -493,6 +548,10 @@ class LocalRoutineParser:
                 "SubRoutine request can have have at most one request."
             )
         request_name = None if len(request_line) == 0 else request_line[0]
+        if request_name is not None and not is_valid_name(request_name):
+            raise QoalaParseError(
+                f"SubRoutine {name}: value {request_name} is not a valid name for a request."
+            )
 
         start_line = self._read_line()
         if start_line != "NETQASM_START":
@@ -567,8 +626,8 @@ class RequestRoutineParser:
         return [v.strip() for v in values]
 
     def _parse_request_line_with_vecs(
-        self, key: str, line: str, allow_template: bool = False
-    ) -> List[Union[str, RrReturnVector]]:
+        self, key: str, line: str
+    ) -> List[Union[str, IqoalaVector]]:
         if line.count(":") != 1:
             raise QoalaParseError("SubRoutine Meta lines must have a single colon.")
         split = line.split(":")
@@ -583,7 +642,7 @@ class RequestRoutineParser:
             return []
         values_str = split[1].split(",")
         values_str = [v.strip() for v in values_str]
-        values: List[Union[str, RrReturnVector]] = []
+        values: List[Union[str, IqoalaVector]] = []
         for v in values_str:
             if "<" in v:
                 if v.startswith("<"):
@@ -596,36 +655,53 @@ class RequestRoutineParser:
                     )
                 vec_split = v.split("<")
                 vec_name = vec_split[0]
-                vec_size_str = vec_split[1][:-1]  # strip last ">"
-                vec_size: Union[int, Template]
-                if (
-                    allow_template
-                    and vec_size_str.startswith("{")
-                    and vec_size_str.endswith("}")
-                ):
+                if not is_valid_name(vec_name):
+                    raise QoalaParseError(
+                        f"Value {vec_name} is not a valid variable name."
+                    )
+                vec_size_str = vec_split[1][:-1].strip()  # strip last ">"
+                vec_size: IqoalaValue
+                if vec_size_str.startswith("{") and vec_size_str.endswith("}"):
                     vec_size_str = vec_size_str.strip("{}").strip()
+                    if not is_valid_name(vec_size_str):
+                        raise QoalaParseError(
+                            f"Value {vec_size_str} is not a valid name for a template. "
+                        )
+
                     vec_size = Template(vec_size_str)
                 else:
-                    vec_size = int(vec_size_str)
-                values.append(RrReturnVector(vec_name, vec_size))
+                    try:
+                        vec_size = int(vec_size_str)
+                    except ValueError:
+                        raise QoalaParseError(
+                            "An integer or a template(using '{' and '{') must be provided "
+                            f"as the size of an Iqoala vector {vec_name}."
+                        )
+                values.append(IqoalaVector(vec_name, vec_size))
             else:
+                if not is_valid_name(v):
+                    raise QoalaParseError(f"Value {v} is not a valid variable name.")
                 values.append(v)
         return values
 
-    def _parse_single_int_value(
-        self, key: str, line: str, allow_template: bool = False
-    ) -> Union[int, Template]:
+    def _parse_single_int_value(self, key: str, line: str) -> Union[int, Template]:
         strings = self._parse_request_line(key, line)
         if len(strings) != 1:
             raise QoalaParseError(
-                f"One single integer value is allowed in Request Routine Meta line for {key}."
+                f"One single integer or a template value is allowed in Request Routine Meta line for {key}."
             )
         value = strings[0]
-        if allow_template:
-            if value.startswith("{") and value.endswith("}"):
-                value = value.strip("{}").strip()
-                return Template(value)
-        return int(value)
+        if value.startswith("{") and value.endswith("}"):
+            value = value.strip("{}").strip()
+            if not is_valid_name(value):
+                raise QoalaParseError(
+                    f"Value {value} is not a valid name for a template."
+                )
+            return Template(value)
+        try:
+            return int(value)
+        except ValueError:
+            raise QoalaParseError(f"Value for {key} must be an integer or a template.")
 
     def _parse_optional_str_value(self, key: str, line: str) -> Optional[str]:
         strings = self._parse_request_line(key, line)
@@ -637,24 +713,24 @@ class RequestRoutineParser:
             )
         return strings[0]
 
-    def _parse_int_list_value(self, key: str, line: str) -> List[int]:
-        strings = self._parse_request_line(key, line)
-        return [int(s) for s in strings]
-
-    def _parse_single_float_value(
-        self, key: str, line: str, allow_template: bool = False
-    ) -> Union[float, Template]:
+    def _parse_single_float_value(self, key: str, line: str) -> Union[float, Template]:
         strings = self._parse_request_line(key, line)
         if len(strings) != 1:
             raise QoalaParseError(
                 f"One single floating point value is allowed in Request Routine Meta line for {key}."
             )
         value = strings[0]
-        if allow_template:
-            if value.startswith("{") and value.endswith("}"):
-                value = value.strip("{}").strip()
-                return Template(value)
-        return float(value)
+        if value.startswith("{") and value.endswith("}"):
+            value = value.strip("{}").strip()
+            if not is_valid_name(value):
+                raise QoalaParseError(
+                    f"Value {value} is not a valid name for a template."
+                )
+            return Template(value)
+        try:
+            return float(value)
+        except ValueError:
+            raise QoalaParseError(f"Value for {key} must be a float or a template.")
 
     def _parse_epr_create_role_value(self, key: str, line: str) -> EprRole:
         strings = self._parse_request_line(key, line)
@@ -726,6 +802,10 @@ class RequestRoutineParser:
         callback_type = self._parse_callback_type("callback_type", self._read_line())
 
         callback = self._parse_optional_str_value("callback", self._read_line())
+        if callback is not None and not is_valid_name(callback):
+            raise QoalaParseError(
+                f"Request {name}: Value {callback} is not a valid callback name."
+            )
 
         if callback is not None and callback_type is None:
             raise QoalaParseError(
@@ -736,27 +816,16 @@ class RequestRoutineParser:
             callback_type = CallbackType.WAIT_ALL
 
         return_vars = self._parse_request_line_with_vecs(
-            "return_vars", self._read_line(), allow_template=True
+            "return_vars", self._read_line()
         )
         assert all(" " not in v for v in return_vars if isinstance(v, str))
 
-        remote_id = self._parse_single_int_value(
-            "remote_id", self._read_line(), allow_template=True
-        )
-        epr_socket_id = self._parse_single_int_value(
-            "epr_socket_id", self._read_line(), allow_template=True
-        )
-        num_pairs = self._parse_single_int_value(
-            "num_pairs", self._read_line(), allow_template=True
-        )
-        # virt_ids = self._parse_int_list_value("virt_ids", self._read_line())
+        remote_id = self._parse_single_int_value("remote_id", self._read_line())
+        epr_socket_id = self._parse_single_int_value("epr_socket_id", self._read_line())
+        num_pairs = self._parse_single_int_value("num_pairs", self._read_line())
         virt_ids = self._parse_virt_ids("virt_ids", self._read_line())
-        timeout = self._parse_single_int_value(
-            "timeout", self._read_line(), allow_template=True
-        )
-        fidelity = self._parse_single_float_value(
-            "fidelity", self._read_line(), allow_template=True
-        )
+        timeout = self._parse_single_int_value("timeout", self._read_line())
+        fidelity = self._parse_single_float_value("fidelity", self._read_line())
         typ = self._parse_epr_create_type_value("typ", self._read_line())
         role = self._parse_epr_create_role_value("role", self._read_line())
 

--- a/qoala/lang/parse.py
+++ b/qoala/lang/parse.py
@@ -164,12 +164,16 @@ class IqoalaMetaParser:
 
 
 class IqoalaInstrParser:
-    def __init__(self, text: str) -> None:
+    def __init__(
+        self, text: str, defined_vectors: Dict[str, hl.IqoalaVector] = None
+    ) -> None:
         self._text = text
         lines = [line.strip() for line in text.split("\n")]
         self._lines = [line for line in lines if len(line) > 0]
         self._lineno: int = 0
-        self._defined_vectors: Dict[str, hl.IqoalaVector] = {}  # name -> vector
+        self._defined_vectors: Dict[str, hl.IqoalaVector] = {}
+        if defined_vectors is not None:
+            self._defined_vectors = defined_vectors
 
     def _next_line(self) -> None:
         self._lineno += 1
@@ -337,6 +341,7 @@ class HostCodeParser:
         lines = [line.strip() for line in text.split("\n")]
         self._lines = [line for line in lines if len(line) > 0]
         self._lineno: int = 0
+        self._defined_vectors: Dict[str, hl.IqoalaVector] = {}  # name -> vector
 
     def get_block_texts(self) -> List[str]:
         block_start_lines: List[int] = []
@@ -432,7 +437,9 @@ class HostCodeParser:
         lines = [line for line in lines if len(line) > 0]
         name, typ, deadline = self._parse_block_header(lines[0])
         instr_lines = lines[1:]
-        instrs = IqoalaInstrParser("\n".join(instr_lines)).parse()
+        instrs = IqoalaInstrParser(
+            "\n".join(instr_lines), self._defined_vectors
+        ).parse()
 
         return hl.BasicBlock(name, typ, instrs, deadline)
 

--- a/qoala/lang/parse.py
+++ b/qoala/lang/parse.py
@@ -7,7 +7,7 @@ from netqasm.lang.operand import Template
 from netqasm.lang.parsing.text import parse_text_subroutine
 
 from qoala.lang import hostlang as hl
-from qoala.lang.hostlang import IqoalaValue, IqoalaVector
+from qoala.lang.hostlang import IqoalaSingleton, IqoalaValue, IqoalaVar, IqoalaVector
 from qoala.lang.program import LocalRoutine, ProgramMeta, QoalaProgram
 from qoala.lang.request import (
     CallbackType,
@@ -183,7 +183,7 @@ class IqoalaInstrParser:
                 return line
             # if no non-empty line, will always break on EndOfLineException
 
-    def _parse_var(self, var_str: str) -> Union[str, hl.IqoalaTuple, hl.IqoalaVector]:
+    def _parse_var(self, var_str: str) -> IqoalaVar:
         if var_str.startswith("tuple"):
             if var_str[5] != "<" or not var_str.endswith(">"):
                 raise QoalaParseError(
@@ -230,7 +230,7 @@ class IqoalaInstrParser:
 
             return hl.IqoalaVector(vec_name, vec_size)
         else:
-            return var_str
+            return IqoalaSingleton(var_str)
 
     def _parse_lhr(self) -> hl.ClassicalIqoalaOp:
         line = self._read_line()

--- a/qoala/lang/program.py
+++ b/qoala/lang/program.py
@@ -8,6 +8,7 @@ from qoala.lang.hostlang import (
     BasicBlock,
     BasicBlockType,
     ClassicalIqoalaOp,
+    IqoalaSingleton,
     IqoalaTuple,
     IqoalaVector,
     ReturnResultOp,
@@ -136,17 +137,18 @@ class QoalaProgramBuilder:
     def single_routine(cls, routine: LocalRoutine, args: List[int]) -> QoalaProgram:
         meta = ProgramMeta.empty("name")
         prepare_args: List[ClassicalIqoalaOp] = []
-        arg_names = [f"arg_{i}" for i in range(len(args))]
+        arg_singletons = [IqoalaSingleton(f"arg_{i}") for i in range(len(args))]
 
         for i in range(len(args)):
-            prepare_args.append(AssignCValueOp(arg_names[i], args[i]))
+            prepare_args.append(AssignCValueOp(arg_singletons[i], args[i]))
 
         result_vec = IqoalaVector("result", routine.get_return_size())
+        arg_names = [arg.name for arg in arg_singletons]
         args_tup = IqoalaTuple(arg_names)
         call_instr = RunSubroutineOp(
             result=result_vec, values=args_tup, subrt=routine.name
         )
-        return_instr = ReturnResultOp("result")
+        return_instr = ReturnResultOp(IqoalaSingleton("result"))
 
         instructions = prepare_args + [call_instr, return_instr]
 

--- a/qoala/lang/request.py
+++ b/qoala/lang/request.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional, Union
 
 from netqasm.lang.operand import Template
 
+from qoala.lang.hostlang import IqoalaVector
+
 
 class CallbackType(Enum):
     SEQUENTIAL = 0
@@ -105,8 +107,8 @@ class QoalaRequest:
     epr_socket_id: Union[int, Template]
     num_pairs: Union[int, Template]
     virt_ids: RequestVirtIdMapping
-    timeout: float
-    fidelity: float
+    timeout: Union[float, Template]
+    fidelity: Union[float, Template]
     typ: EprType
     role: EprRole
 
@@ -142,21 +144,12 @@ class QoalaRequest:
         return self.serialize()
 
 
-@dataclass(frozen=True)
-class RrReturnVector:
-    name: str
-    size: Union[int, Template]
-
-    def __str__(self) -> str:
-        return f"{self.name}<{self.size}>"
-
-
 @dataclass
 class RequestRoutine:
     name: str
     request: QoalaRequest
 
-    return_vars: List[Union[str, RrReturnVector]]
+    return_vars: List[Union[str, IqoalaVector]]
 
     callback_type: CallbackType
     callback: Optional[str]  # Local Routine name
@@ -164,20 +157,20 @@ class RequestRoutine:
     def instantiate(self, values: Dict[str, Any]) -> None:
         for i in range(len(self.return_vars)):
             ret_var = self.return_vars[i]
-            if isinstance(ret_var, RrReturnVector):
+            if isinstance(ret_var, IqoalaVector):
                 if isinstance(ret_var.size, Template):
                     size = values[ret_var.size.name]
                     print(f"instantiating ret_var {ret_var.name} with size {size}")
-                    self.return_vars[i] = RrReturnVector(ret_var.name, size)
+                    self.return_vars[i] = IqoalaVector(ret_var.name, size)
         self.request.instantiate(values)
 
     def get_return_size(self, prog_input: Optional[Dict[str, int]] = None) -> int:
         size = 0
         for v in self.return_vars:
-            if isinstance(v, RrReturnVector):
+            if isinstance(v, IqoalaVector):
                 if isinstance(v.size, int):
                     size += v.size
-                else:
+                elif isinstance(v.size, Template):
                     # Size is a template. It should be in the Program Input.
                     assert prog_input is not None
                     size += prog_input[v.size.name]

--- a/qoala/lang/routine.py
+++ b/qoala/lang/routine.py
@@ -5,6 +5,8 @@ from typing import List, Optional, Union
 
 from netqasm.lang.subroutine import Subroutine
 
+from qoala.lang.hostlang import IqoalaVector
+
 
 @dataclass
 class RoutineMetadata:
@@ -26,26 +28,18 @@ class RoutineMetadata:
 
 
 @dataclass(frozen=True)
-class LrReturnVector:
-    name: str
-    size: int
-
-    def __str__(self) -> str:
-        return f"{self.name}<{self.size}>"
-
-
-@dataclass(frozen=True)
 class LocalRoutine:
     name: str
     subroutine: Subroutine
-    return_vars: List[Union[str, LrReturnVector]]
+    return_vars: List[Union[str, IqoalaVector]]
     metadata: RoutineMetadata
     request_name: Optional[str] = None
 
     def get_return_size(self) -> int:
         size = 0
         for v in self.return_vars:
-            if isinstance(v, LrReturnVector):
+            if isinstance(v, IqoalaVector):
+                assert isinstance(v.size, int)
                 size += v.size
             else:
                 size += 1

--- a/qoala/sim/host/hostprocessor.py
+++ b/qoala/sim/host/hostprocessor.py
@@ -210,12 +210,14 @@ class HostProcessor:
             host_mem.write(loc, result)
         elif isinstance(instr, hostlang.ReturnResultOp):
             yield from self._interface.wait(first_half)
-            assert isinstance(instr.arguments[0], hostlang.IqoalaSingleton)
+            assert isinstance(
+                instr.arguments[0], hostlang.IqoalaSingleton
+            ) or isinstance(instr.arguments[0], hostlang.IqoalaVector)
             loc = instr.arguments[0].name
-            # TODO: improve this
-            try:
+            print(type(instr.arguments[0]))
+            if isinstance(instr.arguments[0], hostlang.IqoalaSingleton):
                 value = host_mem.read(loc)
-            except KeyError:
+            else:
                 value = host_mem.read_vec(loc)
             self._logger.debug(f"returning {loc} = {value}")
             # Simulate instruction duration.

--- a/qoala/sim/host/hostprocessor.py
+++ b/qoala/sim/host/hostprocessor.py
@@ -94,7 +94,6 @@ class HostProcessor:
             yield from self._interface.wait(first_half)
             value = instr.attributes[0]
             assert isinstance(value, int)
-            print(type(instr.results))
             assert isinstance(instr.results, hostlang.IqoalaSingleton)
             loc = instr.results.name  # type: ignore
             self._logger.debug(f"writing {value} to {loc}")
@@ -214,7 +213,6 @@ class HostProcessor:
                 instr.arguments[0], hostlang.IqoalaSingleton
             ) or isinstance(instr.arguments[0], hostlang.IqoalaVector)
             loc = instr.arguments[0].name
-            print(type(instr.arguments[0]))
             if isinstance(instr.arguments[0], hostlang.IqoalaSingleton):
                 value = host_mem.read(loc)
             else:
@@ -458,8 +456,6 @@ class HostProcessor:
         result_vars_len = self._calculate_result_size(instr.results, prog_input)
         assert len(all_results) == result_vars_len
 
-        print(type(instr.results), ":", instr.results)
-
         # Collect the host variables to which to copy these results.
         if isinstance(instr.results, hostlang.IqoalaSingleton):
             loc = instr.results.name
@@ -482,7 +478,6 @@ class HostProcessor:
         results: hostlang.IqoalaVar,
         prog_input: Optional[Dict[str, int]] = None,
     ) -> int:
-        print(type(results))
         if results is None:
             return 0
         elif isinstance(results, hostlang.IqoalaTuple):

--- a/qoala/sim/scheduler.py
+++ b/qoala/sim/scheduler.py
@@ -12,6 +12,7 @@ from netsquid.components.component import Component, Port
 from netsquid.protocols import Protocol
 
 from pydynaa import EventExpression
+from qoala.lang import hostlang
 from qoala.lang.ehi import (
     EhiNetworkInfo,
     EhiNetworkSchedule,
@@ -839,8 +840,8 @@ class CpuEdfScheduler(EdfScheduler):
         block = process.program.get_block(task.block_name)
         instr = block.instructions[0]
         assert isinstance(instr, ReceiveCMsgOp)
-        assert isinstance(instr.arguments[0], str)
-        csck_id = process.host_mem.read(instr.arguments[0])
+        assert isinstance(instr.arguments[0], hostlang.IqoalaSingleton)
+        csck_id = process.host_mem.read(instr.arguments[0].name)
         csck = process.csockets[csck_id]
         remote_name = csck.remote_name
         remote_pid = csck.remote_pid

--- a/tests/host/test_hostprocessor.py
+++ b/tests/host/test_hostprocessor.py
@@ -33,9 +33,8 @@ from qoala.lang.request import (
     QoalaRequest,
     RequestRoutine,
     RequestVirtIdMapping,
-    RrReturnVector,
 )
-from qoala.lang.routine import LocalRoutine, LrReturnVector, RoutineMetadata
+from qoala.lang.routine import LocalRoutine, RoutineMetadata
 from qoala.runtime.memory import ProgramMemory
 from qoala.runtime.message import Message
 from qoala.runtime.program import ProgramInput, ProgramInstance, ProgramResult
@@ -334,7 +333,7 @@ def test_prepare_lr_call():
     subrt = Subroutine()
     metadata = RoutineMetadata.use_none()
     routine = LocalRoutine(
-        "subrt1", subrt, return_vars=[LrReturnVector("res", 3)], metadata=metadata
+        "subrt1", subrt, return_vars=[IqoalaVector("res", 3)], metadata=metadata
     )
     instr = RunSubroutineOp(
         result=IqoalaVector("res", 3), values=IqoalaTuple([]), subrt="subrt1"
@@ -358,7 +357,7 @@ def test_post_lr_call():
     subrt = Subroutine()
     metadata = RoutineMetadata.use_none()
     routine = LocalRoutine(
-        "subrt1", subrt, return_vars=[LrReturnVector("res", 3)], metadata=metadata
+        "subrt1", subrt, return_vars=[IqoalaVector("res", 3)], metadata=metadata
     )
     instr = RunSubroutineOp(
         result=IqoalaVector("res", 3), values=IqoalaTuple([]), subrt="subrt1"
@@ -410,7 +409,7 @@ def test_prepare_rr_call():
         role=EprRole.CREATE,
     )
     routine = RequestRoutine(
-        "req", request, [RrReturnVector("outcomes", 10)], CallbackType.WAIT_ALL, None
+        "req", request, [IqoalaVector("outcomes", 10)], CallbackType.WAIT_ALL, None
     )
     instr = RunRequestOp(
         result=IqoalaVector("outcomes", 10), values=IqoalaTuple([]), routine="req"
@@ -434,7 +433,7 @@ def test_prepare_rr_call_with_callbacks():
     subrt = Subroutine()
     metadata = RoutineMetadata.use_none()
     local_routine = LocalRoutine(
-        "subrt1", subrt, return_vars=[LrReturnVector("res", 3)], metadata=metadata
+        "subrt1", subrt, return_vars=[IqoalaVector("res", 3)], metadata=metadata
     )
 
     request = create_simple_request(
@@ -475,7 +474,7 @@ def test_post_rr_call_with_callbacks():
     subrt = Subroutine()
     metadata = RoutineMetadata.use_none()
     local_routine = LocalRoutine(
-        "subrt1", subrt, return_vars=[LrReturnVector("res", 3)], metadata=metadata
+        "subrt1", subrt, return_vars=[IqoalaVector("res", 3)], metadata=metadata
     )
 
     request = create_simple_request(

--- a/tests/host/test_hostprocessor.py
+++ b/tests/host/test_hostprocessor.py
@@ -16,6 +16,7 @@ from qoala.lang.hostlang import (
     BasicBlockType,
     BitConditionalMultiplyConstantCValueOp,
     ClassicalIqoalaOp,
+    IqoalaSingleton,
     IqoalaTuple,
     IqoalaVector,
     MultiplyConstantCValueOp,
@@ -176,7 +177,7 @@ def test_initialize():
 def test_assign_cvalue():
     interface = MockHostInterface()
     processor = HostProcessor(interface, HostLatencies.all_zero())
-    program = create_program(instrs=[AssignCValueOp("x", 3)])
+    program = create_program(instrs=[AssignCValueOp(IqoalaSingleton("x"), 3)])
     process = create_process(program, interface)
     processor.initialize(process)
 
@@ -190,7 +191,7 @@ def test_assign_cvalue_with_latencies():
     interface = MockHostInterface()
     latencies = HostLatencies(host_instr_time=500)
     processor = HostProcessor(interface, latencies)
-    program = create_program(instrs=[AssignCValueOp("x", 3)])
+    program = create_program(instrs=[AssignCValueOp(IqoalaSingleton("x"), 3)])
     process = create_process(program, interface)
     processor.initialize(process)
 
@@ -205,7 +206,9 @@ def test_send_msg():
     processor = HostProcessor(interface, HostLatencies.all_zero())
     meta = ProgramMeta.empty("alice")
     meta.csockets = {0: "bob"}
-    program = create_program(instrs=[SendCMsgOp("bob", "msg")], meta=meta)
+    program = create_program(
+        instrs=[SendCMsgOp(IqoalaSingleton("bob"), IqoalaSingleton("msg"))], meta=meta
+    )
     process = create_process(program, interface, inputs={"bob": 0, "msg": 12})
     processor.initialize(process)
 
@@ -218,7 +221,10 @@ def test_recv_msg():
     processor = HostProcessor(interface, HostLatencies.all_zero())
     meta = ProgramMeta.empty("alice")
     meta.csockets = {0: "bob"}
-    program = create_program(instrs=[ReceiveCMsgOp("bob", "msg")], meta=meta)
+    program = create_program(
+        instrs=[ReceiveCMsgOp(IqoalaSingleton("bob"), IqoalaSingleton("msg"))],
+        meta=meta,
+    )
     process = create_process(program, interface, inputs={"bob": 0})
     processor.initialize(process)
 
@@ -235,7 +241,10 @@ def test_recv_msg_with_latencies():
     processor = HostProcessor(interface, latencies)
     meta = ProgramMeta.empty("alice")
     meta.csockets = {0: "bob"}
-    program = create_program(instrs=[ReceiveCMsgOp("bob", "msg")], meta=meta)
+    program = create_program(
+        instrs=[ReceiveCMsgOp(IqoalaSingleton("bob"), IqoalaSingleton("msg"))],
+        meta=meta,
+    )
     process = create_process(program, interface, inputs={"bob": 0})
     processor.initialize(process)
 
@@ -251,9 +260,11 @@ def test_add_cvalue():
     processor = HostProcessor(interface, HostLatencies.all_zero())
     program = create_program(
         instrs=[
-            AssignCValueOp("a", 2),
-            AssignCValueOp("b", 3),
-            AddCValueOp("sum", "a", "b"),
+            AssignCValueOp(IqoalaSingleton("a"), 2),
+            AssignCValueOp(IqoalaSingleton("b"), 3),
+            AddCValueOp(
+                IqoalaSingleton("sum"), IqoalaSingleton("a"), IqoalaSingleton("b")
+            ),
         ]
     )
     process = create_process(program, interface)
@@ -272,9 +283,11 @@ def test_add_cvalue_with_latencies():
     processor = HostProcessor(interface, HostLatencies(host_instr_time=1200))
     program = create_program(
         instrs=[
-            AssignCValueOp("a", 2),
-            AssignCValueOp("b", 3),
-            AddCValueOp("sum", "a", "b"),
+            AssignCValueOp(IqoalaSingleton("a"), 2),
+            AssignCValueOp(IqoalaSingleton("b"), 3),
+            AddCValueOp(
+                IqoalaSingleton("sum"), IqoalaSingleton("a"), IqoalaSingleton("b")
+            ),
         ]
     )
     process = create_process(program, interface)
@@ -292,7 +305,12 @@ def test_multiply_const():
     interface = MockHostInterface()
     processor = HostProcessor(interface, HostLatencies.all_zero())
     program = create_program(
-        instrs=[AssignCValueOp("a", 4), MultiplyConstantCValueOp("result", "a", -1)]
+        instrs=[
+            AssignCValueOp(IqoalaSingleton("a"), 4),
+            MultiplyConstantCValueOp(
+                IqoalaSingleton("result"), IqoalaSingleton("a"), -1
+            ),
+        ]
     )
     process = create_process(program, interface)
     processor.initialize(process)
@@ -308,12 +326,22 @@ def test_bit_cond_mult():
     processor = HostProcessor(interface, HostLatencies.all_zero())
     program = create_program(
         instrs=[
-            AssignCValueOp("var1", 4),
-            AssignCValueOp("var2", 7),
-            AssignCValueOp("cond1", 0),
-            AssignCValueOp("cond2", 1),
-            BitConditionalMultiplyConstantCValueOp("result1", "var1", "cond1", -1),
-            BitConditionalMultiplyConstantCValueOp("result2", "var2", "cond2", -1),
+            AssignCValueOp(IqoalaSingleton("var1"), 4),
+            AssignCValueOp(IqoalaSingleton("var2"), 7),
+            AssignCValueOp(IqoalaSingleton("cond1"), 0),
+            AssignCValueOp(IqoalaSingleton("cond2"), 1),
+            BitConditionalMultiplyConstantCValueOp(
+                IqoalaSingleton("result1"),
+                IqoalaSingleton("var1"),
+                IqoalaSingleton("cond1"),
+                -1,
+            ),
+            BitConditionalMultiplyConstantCValueOp(
+                IqoalaSingleton("result2"),
+                IqoalaSingleton("var2"),
+                IqoalaSingleton("cond2"),
+                -1,
+            ),
         ]
     )
     process = create_process(program, interface)
@@ -513,7 +541,10 @@ def test_return_result():
     interface = MockHostInterface()
     processor = HostProcessor(interface, HostLatencies.all_zero())
     program = create_program(
-        instrs=[AssignCValueOp("result", 2), ReturnResultOp("result")]
+        instrs=[
+            AssignCValueOp(IqoalaSingleton("result"), 2),
+            ReturnResultOp(IqoalaSingleton("result")),
+        ]
     )
     process = create_process(program, interface)
     processor.initialize(process)

--- a/tests/host/test_hostprocessor.py
+++ b/tests/host/test_hostprocessor.py
@@ -206,6 +206,7 @@ def test_send_msg():
     processor = HostProcessor(interface, HostLatencies.all_zero())
     meta = ProgramMeta.empty("alice")
     meta.csockets = {0: "bob"}
+
     program = create_program(
         instrs=[SendCMsgOp(IqoalaSingleton("bob"), IqoalaSingleton("msg"))], meta=meta
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,8 +12,12 @@ from qoala.lang.hostlang import (
     IqoalaSingleton,
     IqoalaTuple,
     IqoalaVector,
+    IqoalaVectorElement,
+    MultiplyConstantCValueOp,
+    ReceiveCMsgOp,
     RunRequestOp,
     RunSubroutineOp,
+    SendCMsgOp,
 )
 from qoala.lang.parse import (
     HostCodeParser,
@@ -1209,6 +1213,23 @@ def test_parse_file_2():
     assert parsed_program.local_routines["create_epr_1"].request_name == "req1"
 
 
+def test_vector_indexing():
+    text = """
+    send_cmsg(a[0], b)
+    b = recv_cmsg(a[0])
+    b = mult_const(a[0]) : 1
+    """
+
+    instructions = IqoalaInstrParser(text).parse()
+
+    assert len(instructions) == 3
+    csocket = IqoalaVectorElement("a", 0)
+    remote_node = IqoalaSingleton("b")
+    assert instructions[0] == SendCMsgOp(csocket, remote_node)
+    assert instructions[1] == ReceiveCMsgOp(csocket, remote_node)
+    assert instructions[2] == MultiplyConstantCValueOp(remote_node, csocket, 1)
+
+
 if __name__ == "__main__":
     test_parse_incomplete_meta()
     test_parse_meta_no_end()
@@ -1252,3 +1273,4 @@ if __name__ == "__main__":
     test_parse_program_single_text()
     test_parse_file()
     test_parse_file_2()
+    test_vector_indexing()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,13 +9,13 @@ from qoala.lang.hostlang import (
     AssignCValueOp,
     BasicBlockType,
     BusyOp,
-    HostLanguageSyntaxError,
     IqoalaSingleton,
     IqoalaTuple,
     IqoalaVector,
     IqoalaVectorElement,
     MultiplyConstantCValueOp,
     ReceiveCMsgOp,
+    ReturnResultOp,
     RunRequestOp,
     RunSubroutineOp,
     SendCMsgOp,
@@ -1249,13 +1249,16 @@ def test_vector_indexing_error():
 def test_arg_vector_passing():
     text = """
     a<3> = run_request() : req1    
-    send_cmsg(a, b)
+    return_result(a)
     """
 
-    # gives an error because SendCMsgOp expects a singleton as the first argument
-    # but receives a vector.
-    with pytest.raises(HostLanguageSyntaxError):
-        IqoalaInstrParser(text).parse()
+    instructions = IqoalaInstrParser(text).parse()
+    assert len(instructions) == 2
+    vec = IqoalaVector("a", 3)
+    assert instructions[0] == RunRequestOp(
+        result=vec, values=IqoalaTuple([]), routine="req1"
+    )
+    assert instructions[1] == ReturnResultOp(vec)
 
 
 if __name__ == "__main__":

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,6 +9,7 @@ from qoala.lang.hostlang import (
     AssignCValueOp,
     BasicBlockType,
     BusyOp,
+    IqoalaSingleton,
     IqoalaTuple,
     IqoalaVector,
     RunRequestOp,
@@ -107,7 +108,7 @@ x = assign_cval() : 1
     instructions = IqoalaInstrParser(text).parse()
 
     assert len(instructions) == 1
-    assert instructions[0] == AssignCValueOp(result="x", value=1)
+    assert instructions[0] == AssignCValueOp(result=IqoalaSingleton("x"), value=1)
 
 
 def test_parse_2_instr():
@@ -119,8 +120,8 @@ y = assign_cval() : 17
     instructions = IqoalaInstrParser(text).parse()
 
     assert len(instructions) == 2
-    assert instructions[0] == AssignCValueOp(result="x", value=1)
-    assert instructions[1] == AssignCValueOp(result="y", value=17)
+    assert instructions[0] == AssignCValueOp(result=IqoalaSingleton("x"), value=1)
+    assert instructions[1] == AssignCValueOp(result=IqoalaSingleton("y"), value=17)
 
 
 def test_parse_busy():
@@ -258,8 +259,10 @@ def test_parse_block():
     assert block.name == "b0"
     assert block.typ == BasicBlockType.CL
     assert len(block.instructions) == 2
-    assert block.instructions[0] == AssignCValueOp(result="x", value=1)
-    assert block.instructions[1] == AssignCValueOp(result="y", value=17)
+    assert block.instructions[0] == AssignCValueOp(result=IqoalaSingleton("x"), value=1)
+    assert block.instructions[1] == AssignCValueOp(
+        result=IqoalaSingleton("y"), value=17
+    )
 
 
 def test_get_block_texts():
@@ -292,8 +295,12 @@ def test_parse_multiple_blocks():
     assert blocks[0].name == "b0"
     assert blocks[0].typ == BasicBlockType.CL
     assert len(blocks[0].instructions) == 2
-    assert blocks[0].instructions[0] == AssignCValueOp(result="x", value=1)
-    assert blocks[0].instructions[1] == AssignCValueOp(result="y", value=17)
+    assert blocks[0].instructions[0] == AssignCValueOp(
+        result=IqoalaSingleton("x"), value=1
+    )
+    assert blocks[0].instructions[1] == AssignCValueOp(
+        result=IqoalaSingleton("y"), value=17
+    )
 
     assert blocks[1].name == "b1"
     assert blocks[1].typ == BasicBlockType.QL

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -31,9 +31,8 @@ from qoala.lang.request import (
     QoalaRequest,
     RequestRoutine,
     RequestVirtIdMapping,
-    RrReturnVector,
 )
-from qoala.lang.routine import LrReturnVector, RoutineMetadata
+from qoala.lang.routine import RoutineMetadata
 from qoala.util.tests import text_equal
 
 
@@ -403,7 +402,7 @@ SUBROUTINE my_subroutine
         name="my_subroutine",
         subroutine=Subroutine(instructions=expected_instrs, arguments=expected_args),
         metadata=RoutineMetadata.free_all([0, 1]),
-        return_vars=[LrReturnVector("outcomes", 10)],
+        return_vars=[IqoalaVector("outcomes", 10)],
     )
 
 
@@ -544,7 +543,7 @@ REQUEST req1
 
     assert routine == RequestRoutine(
         name="req1",
-        return_vars=[RrReturnVector("outcomes", 3)],
+        return_vars=[IqoalaVector("outcomes", 3)],
         callback_type=CallbackType.SEQUENTIAL,
         callback="subrt1",
         request=QoalaRequest(
@@ -624,7 +623,7 @@ REQUEST req1
 
     assert routine == RequestRoutine(
         name="req1",
-        return_vars=[RrReturnVector("outcomes", Template("N"))],
+        return_vars=[IqoalaVector("outcomes", Template("N"))],
         callback_type=CallbackType.WAIT_ALL,
         callback=None,
         request=QoalaRequest(

--- a/tests/test_procnode.py
+++ b/tests/test_procnode.py
@@ -15,6 +15,7 @@ from qoala.lang.hostlang import (
     BasicBlock,
     BasicBlockType,
     ClassicalIqoalaOp,
+    IqoalaSingleton,
     ReceiveCMsgOp,
     SendCMsgOp,
 )
@@ -326,7 +327,7 @@ def test_initialize():
     ehi = LhiConverter.to_ehi(topology, ntf, latencies)
     unit_module = UnitModule.from_full_ehi(ehi)
 
-    instrs = [AssignCValueOp("x", 3)]
+    instrs = [AssignCValueOp(IqoalaSingleton("x"), 3)]
     subrt1 = simple_subroutine(
         "subrt1",
         """
@@ -426,7 +427,9 @@ def test_classical_comm():
     ehi = LhiConverter.to_ehi(topology, ntf, latencies)
     unit_module = UnitModule.from_full_ehi(ehi)
 
-    alice_instrs = [SendCMsgOp("csocket_id", "message")]
+    alice_instrs = [
+        SendCMsgOp(IqoalaSingleton("csocket_id"), IqoalaSingleton("message"))
+    ]
     alice_meta = ProgramMeta(
         name="alice",
         parameters=["csocket_id", "message"],
@@ -444,7 +447,9 @@ def test_classical_comm():
     alice_procnode.add_process(alice_process)
     alice_host_processor.initialize(alice_process)
 
-    bob_instrs = [ReceiveCMsgOp("csocket_id", "result")]
+    bob_instrs = [
+        ReceiveCMsgOp(IqoalaSingleton("csocket_id"), IqoalaSingleton("result"))
+    ]
     bob_meta = ProgramMeta(
         name="bob", parameters=["csocket_id"], csockets={0: "alice"}, epr_sockets={}
     )
@@ -534,7 +539,9 @@ def test_classical_comm_three_nodes():
     ehi = LhiConverter.to_ehi(topology, ntf, latencies)
     unit_module = UnitModule.from_full_ehi(ehi)
 
-    alice_instrs = [SendCMsgOp("csocket_id", "message")]
+    alice_instrs = [
+        SendCMsgOp(IqoalaSingleton("csocket_id"), IqoalaSingleton("message"))
+    ]
     alice_meta = ProgramMeta(
         name="alice",
         parameters=["csocket_id", "message"],
@@ -552,7 +559,7 @@ def test_classical_comm_three_nodes():
     alice_procnode.add_process(alice_process)
     alice_host_processor.initialize(alice_process)
 
-    bob_instrs = [SendCMsgOp("csocket_id", "message")]
+    bob_instrs = [SendCMsgOp(IqoalaSingleton("csocket_id"), IqoalaSingleton("message"))]
     bob_meta = ProgramMeta(
         name="bob",
         parameters=["csocket_id", "message"],
@@ -571,8 +578,10 @@ def test_classical_comm_three_nodes():
     bob_host_processor.initialize(bob_process)
 
     charlie_instrs = [
-        ReceiveCMsgOp("csocket_id_alice", "result_alice"),
-        ReceiveCMsgOp("csocket_id_bob", "result_bob"),
+        ReceiveCMsgOp(
+            IqoalaSingleton("csocket_id_alice"), IqoalaSingleton("result_alice")
+        ),
+        ReceiveCMsgOp(IqoalaSingleton("csocket_id_bob"), IqoalaSingleton("result_bob")),
     ]
     charlie_meta = ProgramMeta(
         name="bob",

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -16,7 +16,7 @@ from qoala.lang.hostlang import (
     SendCMsgOp,
 )
 from qoala.lang.program import LocalRoutine, ProgramMeta, QoalaProgram
-from qoala.lang.routine import LrReturnVector, RoutineMetadata
+from qoala.lang.routine import RoutineMetadata
 from qoala.util.tests import text_equal
 
 
@@ -174,7 +174,7 @@ SUBROUTINE subrt2
             ],
             arguments=["param1"],
         ),
-        return_vars=[LrReturnVector("outcomes", 10)],
+        return_vars=[IqoalaVector("outcomes", 10)],
         metadata=RoutineMetadata.free_all([0]),
     )
     subrt2 = LocalRoutine(

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -8,6 +8,7 @@ from qoala.lang.hostlang import (
     AssignCValueOp,
     BasicBlock,
     BasicBlockType,
+    IqoalaSingleton,
     IqoalaTuple,
     IqoalaVector,
     ReceiveCMsgOp,
@@ -73,12 +74,18 @@ def test_serialize_host_code_1():
         "b0",
         BasicBlockType.CL,
         instructions=[
-            AssignCValueOp("my_value", 1),
-            AssignCValueOp("remote_id", 0),
-            SendCMsgOp("remote_id", "my_value"),
-            ReceiveCMsgOp("remote_id", "received_value"),
-            AssignCValueOp("new_value", 3),
-            AddCValueOp("my_value", "new_value", "new_value"),
+            AssignCValueOp(IqoalaSingleton("my_value"), 1),
+            AssignCValueOp(IqoalaSingleton("remote_id"), 0),
+            SendCMsgOp(IqoalaSingleton("remote_id"), IqoalaSingleton("my_value")),
+            ReceiveCMsgOp(
+                IqoalaSingleton("remote_id"), IqoalaSingleton("received_value")
+            ),
+            AssignCValueOp(IqoalaSingleton("new_value"), 3),
+            AddCValueOp(
+                IqoalaSingleton("my_value"),
+                IqoalaSingleton("new_value"),
+                IqoalaSingleton("new_value"),
+            ),
         ],
     )
     b1 = BasicBlock(
@@ -93,11 +100,12 @@ def test_serialize_host_code_1():
         "b2",
         BasicBlockType.CL,
         instructions=[
-            ReturnResultOp("m"),
+            ReturnResultOp(IqoalaSingleton("m")),
         ],
     )
 
     program = QoalaProgram(meta=ProgramMeta.empty("alice"), blocks=[b0, b1, b2])
+    print(program.serialize_host_code())
     assert text_equal(program.serialize_host_code(), expected)
 
 


### PR DESCRIPTION
- Removed `LrReturnVector` and `RrReturnVector` and used `IqoalaVector` instead.
- Removed unused `IqoalaAttribute`.
- Removed `allow_template` from methods in `RequestRoutineParser` since they are always True. 
- Added validity checks for the names in `MetaData` s.
- Created `IqoalaSingleton` class as a wrapper for strings and created `IqoalaVar` as a base class for all Iqoala variables
- Now arguments can be `IqoalaVectorElement` s.
- `HostCodeParser` stores defined vectors which enables  `IqoalaVector` s to be passed as an argument without using <> (Regarding issue #89). Also, parser now checks if `IqoalaVector` is initialized before indexing.
- Tests are added to `test_parser.py` and `test_hostprocessor.py` for the abovementioned changes.