### PR TITLE
11 add ion trap

### DIFF
--- a/qoala/lang/ehi.py
+++ b/qoala/lang/ehi.py
@@ -55,8 +55,10 @@ class EhiNodeInfo:
     multi_gate_infos: Dict[
         MultiQubit, List[EhiGateInfo]
     ]  # ordered qubit ID list -> gates
-
     latencies: EhiLatencies
+    all_qubit_gate_infos: Optional[
+        List[EhiGateInfo]
+    ] = None  # gates that are applied to all qubits
 
     def find_single_gate(
         self, qubit_id: int, instr: Type[NetQASMInstruction]
@@ -75,6 +77,17 @@ class EhiNodeInfo:
         if multi not in self.multi_gate_infos:
             return None
         for info in self.multi_gate_infos[multi]:
+            if info.instruction == instr:
+                return info
+        return None
+
+    def find_all_qubit_gate(
+        self, instr: Type[NetQASMInstruction]
+    ) -> Optional[EhiGateInfo]:
+        if self.all_qubit_gate_infos is None:
+            return None
+
+        for info in self.all_qubit_gate_infos:
             if info.instruction == instr:
                 return info
         return None
@@ -124,16 +137,36 @@ class EhiBuilder:
         single_duration: float,
         two_instructions: List[Type[NetQASMInstruction]],
         two_duration: float,
+        all_qubit_duration: float = 0,
+        all_qubit_instructions: List[Type[NetQASMInstruction]] = None,
         latencies: Optional[EhiLatencies] = None,
     ) -> EhiNodeInfo:
-        return cls.fully_uniform(
-            num_qubits=num_qubits,
-            flavour=flavour,
-            qubit_info=cls.perfect_qubit(is_communication=True),
-            single_gate_infos=cls.perfect_gates(single_duration, single_instructions),
-            two_gate_infos=cls.perfect_gates(two_duration, two_instructions),
-            latencies=latencies,
-        )
+        if all_qubit_instructions is None:
+            return cls.fully_uniform(
+                num_qubits=num_qubits,
+                flavour=flavour,
+                qubit_info=cls.perfect_qubit(is_communication=True),
+                single_gate_infos=cls.perfect_gates(
+                    single_duration, single_instructions
+                ),
+                two_gate_infos=cls.perfect_gates(two_duration, two_instructions),
+                latencies=latencies,
+            )
+        else:
+            all_qubit_gate_infos = cls.perfect_gates(
+                all_qubit_duration, all_qubit_instructions
+            )
+            return cls.fully_uniform(
+                num_qubits=num_qubits,
+                flavour=flavour,
+                qubit_info=cls.perfect_qubit(is_communication=True),
+                single_gate_infos=cls.perfect_gates(
+                    single_duration, single_instructions
+                ),
+                two_gate_infos=cls.perfect_gates(two_duration, two_instructions),
+                all_qubit_gate_infos=all_qubit_gate_infos,
+                latencies=latencies,
+            )
 
     @classmethod
     def fully_uniform(
@@ -143,6 +176,7 @@ class EhiBuilder:
         flavour: Type[Flavour],
         single_gate_infos: List[EhiGateInfo],
         two_gate_infos: List[EhiGateInfo],
+        all_qubit_gate_infos: List[EhiGateInfo] = None,
         latencies: Optional[EhiLatencies] = None,
     ) -> EhiNodeInfo:
         q_infos = {i: qubit_info for i in range(num_qubits)}
@@ -156,7 +190,14 @@ class EhiBuilder:
 
         if latencies is None:
             latencies = EhiLatencies.all_zero()
-        return EhiNodeInfo(q_infos, flavour, sg_infos, mg_infos, latencies)
+        return EhiNodeInfo(
+            q_infos,
+            flavour,
+            sg_infos,
+            mg_infos,
+            latencies,
+            all_qubit_gate_infos=all_qubit_gate_infos,
+        )
 
     @classmethod
     def perfect_star(
@@ -264,6 +305,10 @@ class UnitModule:
     @classmethod
     def from_ehi(cls, ehi: EhiNodeInfo, qubit_ids: List[int]) -> UnitModule:
         """Get a subset of an EhiNodeInfo"""
+        for id in qubit_ids:
+            if id not in ehi.qubit_infos:
+                raise ValueError(f"Qubit ID {id} not in EhiNodeInfo")
+
         qubit_infos = {i: ehi.qubit_infos[i] for i in qubit_ids}
         single_gate_infos = {i: ehi.single_gate_infos[i] for i in qubit_ids}
         multi_gate_infos = {
@@ -271,6 +316,9 @@ class UnitModule:
             for (ids, info) in ehi.multi_gate_infos.items()
             if all(id in qubit_ids for id in ids.qubit_ids)
         }
+        all_qubit_gate_infos: Optional[List[EhiGateInfo]] = None
+        if len(ehi.qubit_infos.keys()) == len(qubit_ids):
+            all_qubit_gate_infos = ehi.all_qubit_gate_infos
 
         return UnitModule(
             info=EhiNodeInfo(
@@ -279,6 +327,7 @@ class UnitModule:
                 single_gate_infos,
                 multi_gate_infos,
                 ehi.latencies,
+                all_qubit_gate_infos=all_qubit_gate_infos,
             )
         )
 

--- a/qoala/lang/ehi.py
+++ b/qoala/lang/ehi.py
@@ -137,8 +137,8 @@ class EhiBuilder:
         single_duration: float,
         two_instructions: List[Type[NetQASMInstruction]],
         two_duration: float,
-        all_qubit_duration: float = 0,
         all_qubit_instructions: List[Type[NetQASMInstruction]] = None,
+        all_qubit_duration: float = 0,
         latencies: Optional[EhiLatencies] = None,
     ) -> EhiNodeInfo:
         if all_qubit_instructions is None:
@@ -190,13 +190,14 @@ class EhiBuilder:
 
         if latencies is None:
             latencies = EhiLatencies.all_zero()
+
         return EhiNodeInfo(
             q_infos,
             flavour,
             sg_infos,
             mg_infos,
             latencies,
-            all_qubit_gate_infos=all_qubit_gate_infos,
+            all_qubit_gate_infos=copy.deepcopy(all_qubit_gate_infos),
         )
 
     @classmethod

--- a/qoala/runtime/config.py
+++ b/qoala/runtime/config.py
@@ -349,6 +349,13 @@ class GateConfig(LhiGateConfigInterface, BaseModel):
         return cls.with_depolar_prob(name, duration, depolar_prob)
 
     @classmethod
+    def with_all_qubit_gate_fidelity(
+        cls, name: str, duration: int, fidelity: float, num_qubits: int
+    ) -> GateConfig:
+        depolar_prob = fidelity_to_prob_max_mixed(num_qubits=num_qubits, fid=fidelity)
+        return cls.with_depolar_prob(name, duration, depolar_prob)
+
+    @classmethod
     def from_dict(
         cls,
         dict: Any,
@@ -510,6 +517,17 @@ class MultiGateConfig(BaseModel):
         )
 
 
+class AllQubitGateConfig(BaseModel):
+    gate_configs: List[GateConfig]
+
+    @classmethod
+    def from_dict(cls, dict: Any) -> AllQubitGateConfig:
+        print(dict)
+        return AllQubitGateConfig(
+            gate_configs=[GateConfig.from_dict(d) for d in dict["gate_configs"]],
+        )
+
+
 # Topology config.
 
 
@@ -517,6 +535,7 @@ class TopologyConfig(BaseModel, LhiTopologyConfigInterface):
     qubits: List[QubitIdConfig]
     single_gates: List[SingleGateConfig]
     multi_gates: List[MultiGateConfig]
+    all_qubit_gates: Optional[AllQubitGateConfig] = None
 
     @classmethod
     def from_file(cls, path: str) -> TopologyConfig:
@@ -532,6 +551,8 @@ class TopologyConfig(BaseModel, LhiTopologyConfigInterface):
         single_duration: int,
         two_instructions: List[str],
         two_duration: int,
+        all_qubit_gate_instructions: List[str] = None,
+        all_qubit_gate_duration: int = 0,
     ) -> TopologyConfig:
         qubits = [
             QubitIdConfig(
@@ -568,8 +589,22 @@ class TopologyConfig(BaseModel, LhiTopologyConfigInterface):
                 )
                 multi_gates.append(cfg)
 
+        all_qubit_gates = None
+        if all_qubit_gate_instructions is not None:
+            all_qubit_gates = AllQubitGateConfig(
+                gate_configs=[
+                    GateConfig.perfect_config(
+                        name=name, duration=all_qubit_gate_duration
+                    )
+                    for name in all_qubit_gate_instructions
+                ]
+            )
+
         return TopologyConfig(
-            qubits=qubits, single_gates=single_gates, multi_gates=multi_gates
+            qubits=qubits,
+            single_gates=single_gates,
+            multi_gates=multi_gates,
+            all_qubit_gates=all_qubit_gates,
         )
 
     @classmethod
@@ -580,6 +615,8 @@ class TopologyConfig(BaseModel, LhiTopologyConfigInterface):
         single_duration: int,
         two_instructions: List[str],
         two_duration: int,
+        all_qubit_gate_instructions: List[str] = None,
+        all_qubit_gate_duration: int = 0,
     ) -> TopologyConfig:
         return cls.uniform_t1t2_qubits_perfect_gates(
             num_qubits=num_qubits,
@@ -589,6 +626,8 @@ class TopologyConfig(BaseModel, LhiTopologyConfigInterface):
             single_duration=single_duration,
             two_instructions=two_instructions,
             two_duration=two_duration,
+            all_qubit_gate_instructions=all_qubit_gate_instructions,
+            all_qubit_gate_duration=all_qubit_gate_duration,
         )
 
     @classmethod
@@ -796,8 +835,15 @@ class TopologyConfig(BaseModel, LhiTopologyConfigInterface):
         single_gates = [SingleGateConfig.from_dict(d) for d in raw_single_gates]
         raw_multi_gates = dict["multi_gates"]
         multi_gates = [MultiGateConfig.from_dict(d) for d in raw_multi_gates]
+        all_qubit_gates = None
+        if "all_qubit_gates" in dict:
+            raw_all_qubit_gates = dict["all_qubit_gates"]
+            all_qubit_gates = AllQubitGateConfig.from_dict(raw_all_qubit_gates)
         return TopologyConfig(
-            qubits=qubits, single_gates=single_gates, multi_gates=multi_gates
+            qubits=qubits,
+            single_gates=single_gates,
+            multi_gates=multi_gates,
+            all_qubit_gates=all_qubit_gates,
         )
 
     def get_qubit_configs(self) -> Dict[int, LhiQubitConfigInterface]:
@@ -819,6 +865,11 @@ class TopologyConfig(BaseModel, LhiTopologyConfigInterface):
         for cfg in self.multi_gates:
             infos[MultiQubit(cfg.qubit_ids)] = cfg.gate_configs
         return infos
+
+    def get_all_qubit_gate_configs(self) -> List[LhiGateConfigInterface]:
+        if self.all_qubit_gates is None:
+            return []
+        return self.all_qubit_gates.gate_configs
 
 
 class TopologyConfigBuilder:
@@ -957,9 +1008,10 @@ class TopologyConfigBuilder:
         qubits = self._build_qubits()
         single_gates = self._build_single_gates()
         multi_gates = self._build_multi_gates()
-
         return TopologyConfig(
-            qubits=qubits, single_gates=single_gates, multi_gates=multi_gates
+            qubits=qubits,
+            single_gates=single_gates,
+            multi_gates=multi_gates,
         )
 
     def num_qubits(self, num: int) -> TopologyConfigBuilder:

--- a/qoala/runtime/config.py
+++ b/qoala/runtime/config.py
@@ -36,6 +36,13 @@ from netsquid_magic.state_delivery_sampler import (
 from pydantic import BaseModel as PydanticBaseModel
 
 from qoala.lang.common import MultiQubit
+from qoala.runtime.instructions import (
+    INSTR_BICHROMATIC,
+    INSTR_MEASURE_ALL,
+    INSTR_ROT_X_ALL,
+    INSTR_ROT_Y_ALL,
+    INSTR_ROT_Z_ALL,
+)
 from qoala.runtime.lhi import (
     INSTR_MEASURE_INSTANT,
     LhiGateConfigInterface,
@@ -51,6 +58,7 @@ from qoala.runtime.ntf import (
     NtfInterface,
     NtfInterfaceConfigInterface,
     NvNtf,
+    TrappedIonNtf,
 )
 from qoala.util.math import fidelity_to_prob_max_mixed
 
@@ -440,6 +448,11 @@ class DefaultInstrConfigRegistry(InstrConfigRegistry):
         "INSTR_CYDIR": INSTR_CYDIR,
         "INSTR_MEASURE": INSTR_MEASURE,
         "INSTR_MEASURE_INSTANT": INSTR_MEASURE_INSTANT,
+        "INSTR_MEASURE_ALL": INSTR_MEASURE_ALL,
+        "INSTR_ROT_X_ALL": INSTR_ROT_X_ALL,
+        "INSTR_ROT_Y_ALL": INSTR_ROT_Y_ALL,
+        "INSTR_ROT_Z_ALL": INSTR_ROT_Z_ALL,
+        "INSTR_BICHROMATIC": INSTR_BICHROMATIC,
     }
 
     @classmethod
@@ -471,6 +484,7 @@ class DefaultNtfRegistry(NtfInterfaceRegistry):
     _MAP = {
         "GenericNtf": GenericNtf,
         "NvNtf": NvNtf,
+        "TrappedIonNtf": TrappedIonNtf,
     }
 
     @classmethod
@@ -522,7 +536,6 @@ class AllQubitGateConfig(BaseModel):
 
     @classmethod
     def from_dict(cls, dict: Any) -> AllQubitGateConfig:
-        print(dict)
         return AllQubitGateConfig(
             gate_configs=[GateConfig.from_dict(d) for d in dict["gate_configs"]],
         )

--- a/qoala/runtime/instructions.py
+++ b/qoala/runtime/instructions.py
@@ -1,0 +1,137 @@
+import functools as ft
+from typing import List, Tuple
+
+import numpy as np
+from netsquid.components.instructions import Instruction
+from netsquid.components.qmemory import QuantumMemory
+from netsquid.qubits import operators as ops
+from scipy.linalg import expm
+
+
+class IMeasAll(Instruction):
+    """
+    Measurement instruction for all qubits in a quantum memory.
+    """
+
+    @property
+    def name(self) -> str:
+        """instruction name."""
+        return "measure_all"
+
+    @property
+    def num_positions(self) -> int:
+        """number of targeted memory positions_of_connections. If -1, number is unrestricted."""
+        return -1
+
+    def execute(
+        self, quantum_memory: QuantumMemory, positions: List[int], **kwargs
+    ) -> List[List[int]]:
+        """Execute instruction on a quantum memory.
+
+        :param quantum_memory: NetSquid Quantum memory to execute instruction on.
+        :param positions: Memory positions_of_connections to execute instruction on.
+        """
+        result = []
+        for pos in positions:
+            result.append(quantum_memory.measure(positions=[pos])[0][0])
+        return [result]
+
+
+class IRotationAllGate(Instruction):
+    """
+    Rotation instruction for all qubits in a quantum memory.
+    """
+
+    def __init__(self, name: str, axis: Tuple[int, int, int]) -> None:
+        self._name = name
+        self._axis = axis
+
+    @property
+    def name(self) -> str:
+        """instruction name."""
+        return self._name
+
+    @property
+    def num_positions(self) -> int:
+        """number of targeted memory positions_of_connections. If -1, number is unrestricted."""
+        return -1
+
+    def execute(
+        self,
+        quantum_memory: QuantumMemory,
+        positions: List[int],
+        angle: float,
+        **kwargs
+    ) -> None:
+        """Execute instruction on a quantum memory.
+
+        :param quantum_memory: NetSquid Quantum memory to execute instruction on.
+        :param positions: Memory positions_of_connections to execute instruction on.
+        """
+        print("executing rotation instruction with angle: ", angle)
+        operator = ops.create_rotation_op(angle=angle, rotation_axis=self._axis)
+        for pos in positions:
+            quantum_memory.operate(positions=pos, operator=operator)
+
+
+class IBichromaticGate(Instruction):
+    """
+    Bichromatic gate instruction.
+    """
+
+    @property
+    def name(self) -> str:
+        """instruction name."""
+        return "bichromatic"
+
+    @property
+    def num_positions(self) -> int:
+        """number of targeted memory positions_of_connections. If -1, number is unrestricted."""
+        return -1
+
+    def construct_operator(self, n: int, angle: float) -> ops.Operator:
+        """Construct operator which is applied by the gate.
+        Used by execute method.
+
+        :param n: Number of qubits to apply operator on.
+        :param angle: Angle of rotation.
+
+        """
+        sub_matrices = []
+        X = np.array([[0, 1], [1, 0]])
+        for i in range(2, n + 1):
+            for j in range(1, i):
+                identity1 = np.eye(2 ** (j - 1))
+                identity2 = np.eye(2 ** (i - j - 1))
+                identity3 = np.eye(2 ** (n - i))
+                sub_matrix_parts = [identity1, X, identity2, X, identity3]
+                sub_matrix = ft.reduce(np.kron, sub_matrix_parts)
+                sub_matrices.append(sub_matrix)
+
+        matrix = expm(-1j * angle / 2 * np.sum(sub_matrices, axis=0))
+        operator = ops.Operator(name="bichromatic_operator", matrix=matrix)
+        return operator
+
+    def execute(
+        self,
+        quantum_memory: QuantumMemory,
+        positions: List[int],
+        angle: float,
+        **kwargs
+    ) -> None:
+        """Execute instruction on a quantum memory.
+
+        :param quantum_memory: NetSquid Quantum memory to execute instruction on.
+        :param positions: Memory positions_of_connections to execute instruction on.
+        """
+
+        operator = self.construct_operator(n=len(positions), angle=angle)
+        print("operator: ", operator)
+        quantum_memory.operate(positions=positions, operator=operator)
+
+
+INSTR_MEASURE_ALL = IMeasAll()
+INSTR_ROT_X_ALL = IRotationAllGate("x_rot_all_gate", axis=(1, 0, 0))
+INSTR_ROT_Y_ALL = IRotationAllGate("y_rot_all_gate", axis=(0, 1, 0))
+INSTR_ROT_Z_ALL = IRotationAllGate("z_rot_all_gate", axis=(0, 0, 1))
+INSTR_BICHROMATIC = IBichromaticGate()

--- a/qoala/runtime/instructions.py
+++ b/qoala/runtime/instructions.py
@@ -20,7 +20,7 @@ class IMeasAll(Instruction):
 
     @property
     def num_positions(self) -> int:
-        """number of targeted memory positions_of_connections. If -1, number is unrestricted."""
+        """number of targeted memory positions. If -1, number is unrestricted."""
         return -1
 
     def execute(
@@ -53,7 +53,7 @@ class IRotationAllGate(Instruction):
 
     @property
     def num_positions(self) -> int:
-        """number of targeted memory positions_of_connections. If -1, number is unrestricted."""
+        """number of targeted memory positions. If -1, number is unrestricted."""
         return -1
 
     def execute(
@@ -86,7 +86,7 @@ class IBichromaticGate(Instruction):
 
     @property
     def num_positions(self) -> int:
-        """number of targeted memory positions_of_connections. If -1, number is unrestricted."""
+        """number of targeted memory positions. If -1, number is unrestricted."""
         return -1
 
     def construct_operator(self, n: int, angle: float) -> ops.Operator:
@@ -122,7 +122,7 @@ class IBichromaticGate(Instruction):
         """Execute instruction on a quantum memory.
 
         :param quantum_memory: NetSquid Quantum memory to execute instruction on.
-        :param positions: Memory positions_of_connections to execute instruction on.
+        :param positions: Memory positions to do instruction on. Can be empty.
         """
 
         operator = self.construct_operator(n=len(positions), angle=angle)

--- a/qoala/runtime/lhi.py
+++ b/qoala/runtime/lhi.py
@@ -201,7 +201,6 @@ class LhiTopologyBuilder:
             ]
 
         all_qubit_gate_infos: Optional[List[LhiGateInfo]] = None
-        print(cfg.get_all_qubit_gate_configs())
         if cfg.get_all_qubit_gate_configs() is not None:
             all_qubit_gate_infos = []
             for info in cfg.get_all_qubit_gate_configs():
@@ -288,8 +287,8 @@ class LhiTopologyBuilder:
         single_duration: float,
         two_instructions: List[NetSquidInstruction],
         two_duration: float,
-        all_qubit_duration: float = 0,
         all_qubit_instructions: List[NetSquidInstruction] = None,
+        all_qubit_duration: float = 0,
     ) -> LhiTopology:
         if all_qubit_instructions is None:
             return cls.fully_uniform(

--- a/qoala/runtime/lhi_to_ehi.py
+++ b/qoala/runtime/lhi_to_ehi.py
@@ -87,6 +87,13 @@ class LhiConverter:
             ids: [cls.gate_info_to_ehi(gi, ntf) for gi in gis]
             for (ids, gis) in topology.multi_gate_infos.items()
         }
+        if topology.all_qubit_gate_infos is None:
+            all_qubit_gate_infos = []
+        else:
+            all_qubit_gate_infos = [
+                cls.gate_info_to_ehi(gi, ntf) for gi in topology.all_qubit_gate_infos
+            ]
+
         flavour = ntf.flavour()
 
         ehi_latencies = EhiLatencies(
@@ -100,6 +107,7 @@ class LhiConverter:
             flavour=flavour,
             single_gate_infos=single_gate_infos,
             multi_gate_infos=multi_gate_infos,
+            all_qubit_gate_infos=all_qubit_gate_infos,
             latencies=ehi_latencies,
         )
 

--- a/qoala/runtime/task.py
+++ b/qoala/runtime/task.py
@@ -722,7 +722,6 @@ class TaskDurationEstimator:
         duration = 0.0
         # TODO: refactor this
         for instr in routine.subroutine.instructions:
-            print("instr", instr)
             if (
                 type(instr)
                 in [

--- a/qoala/runtime/task.py
+++ b/qoala/runtime/task.py
@@ -722,6 +722,7 @@ class TaskDurationEstimator:
         duration = 0.0
         # TODO: refactor this
         for instr in routine.subroutine.instructions:
+            print("instr", instr)
             if (
                 type(instr)
                 in [
@@ -752,9 +753,10 @@ class TaskDurationEstimator:
                 if max_duration != -1:
                     duration += max_duration
                 else:
-                    raise RuntimeError(
-                        f"Gate {type(instr)} not found in EHI. Cannot calculate duration of containing block."
-                    )
+                    return 0
+                    # raise RuntimeError(
+                    #     f"Gate {type(instr)} not found in EHI. Cannot calculate duration of containing block."
+                    # )
         return duration
 
 

--- a/qoala/runtime/task.py
+++ b/qoala/runtime/task.py
@@ -749,13 +749,16 @@ class TaskDurationEstimator:
                     if info := ehi.find_multi_gate(multi.qubit_ids, type(instr)):
                         max_duration = max(max_duration, info.duration)
 
+                if ehi.all_qubit_gate_infos is not None:
+                    for gate_info in ehi.all_qubit_gate_infos:
+                        max_duration = max(max_duration, gate_info.duration)
+
                 if max_duration != -1:
                     duration += max_duration
                 else:
-                    return 0
-                    # raise RuntimeError(
-                    #     f"Gate {type(instr)} not found in EHI. Cannot calculate duration of containing block."
-                    # )
+                    raise RuntimeError(
+                        f"Gate {type(instr)} not found in EHI. Cannot calculate duration of containing block."
+                    )
         return duration
 
 

--- a/qoala/sim/build.py
+++ b/qoala/sim/build.py
@@ -97,7 +97,6 @@ def build_qprocessor_from_topology(
                     **gate_info.error_model_kwargs
                 ),
             )
-            print("phys_instr: ", phys_instr, "topology: ", phys_instr.topology)
             phys_instructions.append(phys_instr)
 
     return QuantumProcessor(

--- a/qoala/sim/build.py
+++ b/qoala/sim/build.py
@@ -87,6 +87,19 @@ def build_qprocessor_from_topology(
             )
             phys_instructions.append(phys_instr)
 
+    if topology.all_qubit_gate_infos is not None:
+        for gate_info in topology.all_qubit_gate_infos:
+            phys_instr = PhysicalInstruction(
+                instruction=gate_info.instruction,
+                duration=gate_info.duration,
+                topology=[tuple(range(num_qubits))],
+                quantum_noise_model=gate_info.error_model(
+                    **gate_info.error_model_kwargs
+                ),
+            )
+            print("phys_instr: ", phys_instr, "topology: ", phys_instr.topology)
+            phys_instructions.append(phys_instr)
+
     return QuantumProcessor(
         name=name,
         num_positions=num_qubits,

--- a/qoala/sim/build.py
+++ b/qoala/sim/build.py
@@ -69,6 +69,7 @@ def build_qprocessor_from_topology(
                 quantum_noise_model=gate_info.error_model(
                     **gate_info.error_model_kwargs
                 ),
+                parallel=True,
             )
             phys_instructions.append(phys_instr)
 

--- a/qoala/sim/memmgr.py
+++ b/qoala/sim/memmgr.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from netsquid.protocols import Protocol
 
@@ -167,3 +167,6 @@ class MemoryManager(Protocol):
             if virt_loc.pid == pid:
                 return virt_loc.virt_id
         return None
+
+    def get_all_qubit_ids(self) -> Set[int]:
+        return self._qdevice.get_all_qubit_ids()

--- a/qoala/sim/netstack/netstackprocessor.py
+++ b/qoala/sim/netstack/netstackprocessor.py
@@ -93,7 +93,7 @@ class NetstackProcessor:
         # doesn't take time.
         commands = [QDeviceCommand(INSTR_MEASURE_INSTANT, [phys_id])]
         m = yield from self.qdevice.execute_commands(commands=commands)
-        assert m is not None
+        assert isinstance(m, int)
         return m
 
     def _handle_multi_pair_ck(

--- a/qoala/sim/qdevice.py
+++ b/qoala/sim/qdevice.py
@@ -55,7 +55,7 @@ class QDevice:
         return len(self.get_non_comm_qubit_ids())
 
     def get_all_qubit_ids(self) -> Set[int]:
-        return {q for q, _ in self.topology.qubit_infos.items()}
+        return {q for q in self.topology.qubit_infos.keys()}
 
     def get_comm_qubit_ids(self) -> Set[int]:
         return {
@@ -100,10 +100,10 @@ class QDevice:
         self.qprocessor.mem_positions[id].in_use = in_use
 
     def execute_commands(
-        self, commands: List[QDeviceCommand]
+        self, commands: List[QDeviceCommand], parallel: bool = False
     ) -> Generator[EventExpression, None, Optional[int]]:
         """Can only return at most 1 measurement result."""
-        prog = QuantumProgram()
+        prog = QuantumProgram(parallel=parallel)
 
         # TODO: rewrite this abomination
 

--- a/qoala/sim/qnos/qnos.py
+++ b/qoala/sim/qnos/qnos.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 from netsquid.protocols import Protocol
 
 from qoala.lang.ehi import EhiNetworkInfo
-from qoala.runtime.ntf import GenericNtf, NtfInterface, NvNtf
+from qoala.runtime.ntf import GenericNtf, NtfInterface, NvNtf, TrappedIonNtf
 from qoala.sim.memmgr import MemoryManager
 from qoala.sim.qdevice import QDevice
 from qoala.sim.qnos.qnoscomp import QnosComponent
 from qoala.sim.qnos.qnosinterface import QnosInterface, QnosLatencies
-from qoala.sim.qnos.qnosprocessor import GenericProcessor, NVProcessor, QnosProcessor
+from qoala.sim.qnos.qnosprocessor import (
+    GenericProcessor,
+    IonTrapProcessor,
+    NVProcessor,
+    QnosProcessor,
+)
 
 
 class Qnos(Protocol):
@@ -51,6 +56,10 @@ class Qnos(Protocol):
             )
         elif isinstance(ntf_interface, NvNtf):
             self._processor = NVProcessor(
+                self._interface, latencies, self._asynchronous
+            )
+        elif isinstance(ntf_interface, TrappedIonNtf):
+            self._processor = IonTrapProcessor(
                 self._interface, latencies, self._asynchronous
             )
         else:

--- a/qoala/sim/qnos/qnosprocessor.py
+++ b/qoala/sim/qnos/qnosprocessor.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from typing import Any, Dict, Generator, Optional, Union
 
 import netsquid as ns
-from netqasm.lang.instr import NetQASMInstruction, core, nv, vanilla
+from netqasm.lang.instr import NetQASMInstruction, core, nv, trapped_ion, vanilla
 from netqasm.lang.operand import Register
 from netsquid.components.instructions import (
     INSTR_CNOT,
@@ -23,6 +23,7 @@ from netsquid.components.instructions import (
     INSTR_Z,
 )
 from netsquid.components.instructions import Instruction as NsInstr
+from netsquid_trappedions.instructions import IonTrapMSGate
 
 from pydynaa import EventExpression
 from qoala.lang.routine import LocalRoutine
@@ -195,6 +196,8 @@ class QnosProcessor:
             return self._interpret_binary_classical_instr(pid, instr)
         elif isinstance(instr, core.BreakpointInstruction):
             return self._interpret_breakpoint(pid, instr)
+        elif isinstance(instr, NetQASMInstruction):
+            return self._interpret_other_instr(pid, instr)
         else:
             raise RuntimeError(f"Invalid instruction {instr}")
 
@@ -514,6 +517,11 @@ class QnosProcessor:
     ) -> Generator[EventExpression, None, None]:
         raise NotImplementedError
 
+    def _interpret_other_instr(
+        self, pid: int, instr: NetQASMInstruction
+    ) -> Generator[EventExpression, None, None]:
+        raise NotImplementedError
+
 
 class GenericProcessor(QnosProcessor):
     """A `Processor` for nodes with a generic quantum hardware."""
@@ -746,5 +754,146 @@ class NVProcessor(QnosProcessor):
             yield from self._do_controlled_rotation(pid, instr, INSTR_CXDIR)
         elif isinstance(instr, nv.ControlledRotYInstruction):
             yield from self._do_controlled_rotation(pid, instr, INSTR_CYDIR)
+        else:
+            raise UnsupportedNetqasmInstructionError
+
+
+class IonTrapProcessor(QnosProcessor):
+    """A `Processor` for nodes with a Ion Trap hardware."""
+
+    def _interpret_init(
+        self, pid: int, instr: core.InitInstruction
+    ) -> Generator[EventExpression, None, None]:
+        qnos_mem = self._prog_mem().qnos_mem
+        virt_id = qnos_mem.get_reg_value(instr.reg)
+        phys_id = self._interface.memmgr.phys_id_for(pid, virt_id)
+        if phys_id is None:
+            raise NotAllocatedError
+        self._logger.debug(
+            f"Performing {instr} on virtual qubit "
+            f"{virt_id} (physical ID: {phys_id})"
+        )
+        commands = [QDeviceCommand(INSTR_INIT, [phys_id])]
+        yield from self.qdevice.execute_commands(commands)
+        return None
+
+    def _interpret_meas(
+        self, pid: int, instr: core.MeasInstruction
+    ) -> Generator[EventExpression, None, None]:
+        qnos_mem = self._prog_mem().qnos_mem
+        virt_id = qnos_mem.get_reg_value(instr.qreg)
+        phys_id = self._interface.memmgr.phys_id_for(pid, virt_id)
+        if phys_id is None:
+            raise NotAllocatedError
+
+        self._logger.debug(
+            f"Measuring qubit {virt_id} (physical ID: {phys_id}), "
+            f"placing the outcome in register {instr.creg}"
+        )
+
+        commands = [QDeviceCommand(INSTR_MEASURE, [phys_id])]
+        outcome = yield from self.qdevice.execute_commands(commands)
+        assert outcome is not None
+        qnos_mem.set_reg_value(instr.creg, outcome)
+        return None
+
+    def _interpret_single_rotation_instr(
+        self, pid: int, instr: core.RotationInstruction
+    ) -> Generator[EventExpression, None, None]:
+        if isinstance(instr, trapped_ion.RotZInstruction):
+            yield from self._do_single_rotation(pid, instr, INSTR_ROT_Z)
+        else:
+            raise UnsupportedNetqasmInstructionError
+        return None
+
+    def _interpret_all_qubit_init(self):
+        qubit_ids = self._interface.memmgr.get_all_qubit_ids()
+        commands = [QDeviceCommand(INSTR_INIT, [phys_id]) for phys_id in qubit_ids]
+        yield from self.qdevice.execute_commands(commands, parallel=True)
+
+    def _interpret_all_qubit_meas(self, instr: trapped_ion.AllQubitsMeasInstruction):
+        pass
+        # qnos_mem = self._prog_mem().qnos_mem
+        #
+        # offset = qnos_mem.get_reg_value(instr.reg)
+        # result_addr = self._routine().result_addr
+        # shared_mem = self._prog_mem().shared_mem
+        #
+        # addr = instr.entry.address.address
+        # # Only allow NetQASM 2.0 input/output addresses
+        # assert isinstance(addr, str)
+        # assert addr == "output"
+        # entry = instr.entry.index
+        # assert isinstance(entry, Register)
+        # index = qnos_mem.get_reg_value(entry)
+        # self._logger.debug(
+        #     f"Measuring all qubits Storing value {value} from register {instr.reg} "
+        #     f"to array entry {instr.entry} (index {entry} = {index})"
+        # )
+        # qubit_ids = self._interface.memmgr.get_all_qubit_ids()
+        # commands = [QDeviceCommand(INSTR_MEASURE, [phys_id]) for phys_id in qubit_ids]
+        # yield from self.qdevice.execute_commands(commands, parallel=True)
+        #
+        # shared_mem.write_lr_out(result_addr, [value], offset=index)
+        #
+        # return None
+
+    def _interpret_all_qubit_rotation(
+        self, instr: trapped_ion.AllQubitsRotationInstruction, ns_instr: NsInstr
+    ):
+        qnos_mem = self._prog_mem().qnos_mem
+
+        if isinstance(instr.angle_num, Register):
+            n = qnos_mem.get_reg_value(instr.angle_num)
+        else:
+            n = instr.angle_num.value
+        if isinstance(instr.angle_denom, Register):
+            d = qnos_mem.get_reg_value(instr.angle_denom)
+        else:
+            d = instr.angle_denom.value
+        angle = self._get_rotation_angle_from_operands(n=n, d=d)
+        self._logger.debug(f"Performing {instr} with angle {angle} on all qubit")
+        qubit_ids = self._interface.memmgr.get_all_qubit_ids()
+        commands = [
+            QDeviceCommand(ns_instr, [phys_id], angle=angle) for phys_id in qubit_ids
+        ]
+        yield from self.qdevice.execute_commands(commands, parallel=True)
+        return None
+
+    def _interpret_bichromatic_instr(self, instr: trapped_ion.BichromaticInstruction):
+        qnos_mem = self._prog_mem().qnos_mem
+
+        if isinstance(instr.angle_num, Register):
+            n = qnos_mem.get_reg_value(instr.angle_num)
+        else:
+            n = instr.angle_num.value
+        if isinstance(instr.angle_denom, Register):
+            d = qnos_mem.get_reg_value(instr.angle_denom)
+        else:
+            d = instr.angle_denom.value
+        angle = self._get_rotation_angle_from_operands(n=n, d=d)
+        self._logger.debug(f"Performing {instr} with angle {angle} on all qubit")
+        qubit_ids = list(self._interface.memmgr.get_all_qubit_ids())
+        num_qubits = len(qubit_ids)
+        ns_instr = IonTrapMSGate(num_positions=num_qubits, theta=angle)
+        commands = [QDeviceCommand(ns_instr, qubit_ids)]
+        yield from self.qdevice.execute_commands(commands)
+        return None
+
+    def _interpret_other_instr(
+        self, pid: int, instr: NetQASMInstruction
+    ) -> Generator[EventExpression, None, None]:
+        if isinstance(instr, trapped_ion.BichromaticInstruction):
+            pass
+        elif isinstance(instr, trapped_ion.AllQubitsInitInstruction):
+            yield from self._interpret_all_qubit_init()
+        elif isinstance(instr, trapped_ion.AllQubitsMeasInstruction):
+            yield from self._interpret_all_qubit_meas(instr)
+        elif isinstance(instr, trapped_ion.AllQubitsRotXInstruction):
+            yield from self._interpret_all_qubit_rotation(instr, INSTR_ROT_X)
+        elif isinstance(instr, trapped_ion.AllQubitsRotYInstruction):
+            yield from self._interpret_all_qubit_rotation(instr, INSTR_ROT_Y)
+        elif isinstance(instr, trapped_ion.AllQubitsRotZInstruction):
+            yield from self._interpret_all_qubit_rotation(instr, INSTR_ROT_Z)
         else:
             raise UnsupportedNetqasmInstructionError

--- a/qoala/sim/scheduler.py
+++ b/qoala/sim/scheduler.py
@@ -960,7 +960,6 @@ class CpuEdfScheduler(EdfScheduler):
             self._status = SchedulerStatus(status=set(), params={})
             self.update_external_predcessors()
             self.update_status()
-            print(self.name, ns.sim_time(), f"status: {self.status.status}")
             self._task_logger.debug(f"status: {self.status.status}")
             if Status.NEXT_TASK in self.status.status:
                 task_id = self.status.params["task_id"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     scipy>=1.4.1,<2.0.0
     netsquid >=1.0.6, <2.0
     netsquid-magic >=13.3, <14.0.0
-    netqasm ==0.13.0a5
+    netqasm ==0.13.0a6
     networkx ==3.1
     matplotlib ==3.6.3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     numpy >=1.22, <1.23
     pydantic >=1.8.2
     pydynaa >=0.3, <1.0
+    scipy>=1.4.1,<2.0.0
     netsquid >=1.0.6, <2.0
     netsquid-magic >=13.3, <14.0.0
     netqasm ==0.13.0a4

--- a/tests/configs/ntf_3.yaml
+++ b/tests/configs/ntf_3.yaml
@@ -1,0 +1,1 @@
+ntf_interface_cls: TrappedIonNtf

--- a/tests/configs/topology_cfg_4.yaml
+++ b/tests/configs/topology_cfg_4.yaml
@@ -45,3 +45,10 @@ multi_gates:
         noise_config_cls: "GateDepolariseConfig"
         noise_config:
           <<: *gate_noise
+
+all_qubit_gates:
+  gate_configs:
+    - name: "INSTR_ROT_X_ALL"
+      noise_config_cls: "GateDepolariseConfig"
+      noise_config:
+        <<: *gate_noise

--- a/tests/configs/topology_cfg_7.yaml
+++ b/tests/configs/topology_cfg_7.yaml
@@ -1,0 +1,32 @@
+qubit_noise: &qubit_noise
+  T1: 1_000_000
+  T2: 3_000_000
+
+qubits:
+  - qubit_id: 0
+    qubit_config:
+      is_communication: true
+      noise_config_cls: "QubitT1T2Config"
+      noise_config:
+        <<: *qubit_noise
+  - qubit_id: 1
+    qubit_config:
+      is_communication: true
+      noise_config_cls: "QubitT1T2Config"
+      noise_config:
+        <<: *qubit_noise
+
+gate_noise: &gate_noise
+  duration: 4_000
+  depolarise_prob: 0.2
+
+single_gates: []
+
+multi_gates: []
+
+all_qubit_gates:
+  gate_configs:
+    - name: "INSTR_ROT_X_ALL"
+      noise_config_cls: "GateDepolariseConfig"
+      noise_config:
+        <<: *gate_noise

--- a/tests/qnos/test_qnosprocessor_quantum.py
+++ b/tests/qnos/test_qnosprocessor_quantum.py
@@ -1057,7 +1057,10 @@ def test_measure_all():
             meas_all Q0 @output
             """
     process = create_process_with_trapped_ion_subrt(
-        0, subrt, unit_module, [0, 1, 2],
+        0,
+        subrt,
+        unit_module,
+        [0, 1, 2],
     )
     process.shared_mem.allocate_lr_out(3)
     processor._interface.memmgr.add_process(process)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -5,6 +5,7 @@ from netsquid.components.instructions import (
     INSTR_INIT,
     INSTR_MEASURE,
     INSTR_ROT_X,
+    INSTR_ROT_Z,
     INSTR_X,
     INSTR_Y,
     INSTR_Z,
@@ -23,6 +24,7 @@ from qoala.runtime.config import (
     ProcNodeNetworkConfig,
     TopologyConfig,
 )
+from qoala.runtime.instructions import INSTR_MEASURE_ALL, INSTR_ROT_X_ALL
 from qoala.runtime.lhi import (
     LhiGateInfo,
     LhiLatencies,
@@ -70,6 +72,7 @@ def uniform_topology(num_qubits: int) -> LhiTopology:
             },
         )
     ]
+
     return LhiTopologyBuilder.fully_uniform(
         num_qubits=num_qubits,
         qubit_info=qubit_info,
@@ -96,6 +99,32 @@ def test_build_from_topology():
         proc.get_instruction_duration(INSTR_CNOT, [0, 1])
         == topology.find_multi_gate([0, 1], INSTR_CNOT).duration
     )
+
+
+def test_build_from_topology_with_all_qubit_gates():
+    num_qubits = 3
+    topology = LhiTopologyBuilder.perfect_uniform(
+        num_qubits=num_qubits,
+        single_instructions=[INSTR_INIT, INSTR_MEASURE, INSTR_ROT_Z],
+        single_duration=5e3,
+        two_instructions=[],
+        two_duration=100e3,
+        all_qubit_instructions=[INSTR_ROT_X_ALL, INSTR_MEASURE_ALL],
+        all_qubit_duration=50e3,
+    )
+    proc: QuantumProcessor = build_qprocessor_from_topology("proc", topology)
+    assert proc.num_positions == num_qubits
+
+    for i in range(num_qubits):
+        assert (
+            proc.get_instruction_duration(INSTR_ROT_Z, [i])
+            == topology.find_single_gate(i, INSTR_ROT_Z).duration
+        )
+        with pytest.raises(MissingInstructionError):
+            proc.get_instruction_duration(INSTR_X, [i])
+
+    assert proc.get_instruction_duration(INSTR_ROT_X_ALL, [0, 1, 2]) == 50e3
+    assert proc.get_instruction_duration(INSTR_MEASURE_ALL, [0, 1, 2]) == 50e3
 
 
 def test_build_perfect_topology():

--- a/tests/test_ehi.py
+++ b/tests/test_ehi.py
@@ -2,7 +2,6 @@ from typing import List
 
 import pytest
 from netqasm.lang.instr import core, nv, trapped_ion
-
 from netqasm.lang.instr.flavour import NVFlavour
 
 from qoala.lang.common import MultiQubit

--- a/tests/test_lhi.py
+++ b/tests/test_lhi.py
@@ -22,7 +22,15 @@ from netsquid_magic.state_delivery_sampler import (
 
 from qoala.lang.common import MultiQubit
 from qoala.runtime.config import LatenciesConfig, LinkConfig, NvParams, TopologyConfig
+from qoala.runtime.instructions import (
+    INSTR_BICHROMATIC,
+    INSTR_MEASURE_ALL,
+    INSTR_ROT_X_ALL,
+    INSTR_ROT_Y_ALL,
+    INSTR_ROT_Z_ALL,
+)
 from qoala.runtime.lhi import (
+    INSTR_MEASURE_INSTANT,
     LhiGateInfo,
     LhiLatencies,
     LhiLinkInfo,
@@ -76,14 +84,25 @@ def test_topology():
             "time_independent": True,
         },
     )
+    all_rot_x_gate_info = LhiGateInfo(
+        instruction=INSTR_ROT_X_ALL,
+        duration=1e4,
+        error_model=DepolarNoiseModel,
+        error_model_kwargs={
+            "depolar_rate": 0.2,
+            "time_independent": True,
+        },
+    )
 
     qubit_infos = {0: comm_qubit_info, 1: mem_qubit_info}
     single_gate_infos = {0: [gate_x_info, gate_y_info], 1: [gate_x_info]}
     multi_gate_infos = {MultiQubit([0, 1]): [cnot_gate_info]}
+    all_qubit_gate_infos = [all_rot_x_gate_info]
     topology = LhiTopology(
         qubit_infos=qubit_infos,
         single_gate_infos=single_gate_infos,
         multi_gate_infos=multi_gate_infos,
+        all_qubit_gate_infos=all_qubit_gate_infos,
     )
 
     assert topology.qubit_infos[0].is_communication
@@ -99,6 +118,11 @@ def test_topology():
         info.instruction for info in topology.multi_gate_infos[MultiQubit([0, 1])]
     ]
     assert q01_gates == [INSTR_CNOT]
+
+    assert [INSTR_ROT_X_ALL] == [
+        info.instruction for info in topology.all_qubit_gate_infos
+    ]
+    assert all_rot_x_gate_info == topology.find_all_qubit_gate(INSTR_ROT_X_ALL)
 
 
 def test_topology_from_config():
@@ -118,6 +142,10 @@ def test_topology_from_config():
         info.instruction for info in topology.multi_gate_infos[MultiQubit([0, 1])]
     ]
     assert q01_gates == [INSTR_CNOT]
+
+    assert [INSTR_ROT_X_ALL] == [
+        info.instruction for info in topology.all_qubit_gate_infos
+    ]
 
 
 def test_topology_from_config_2():
@@ -252,12 +280,16 @@ def test_perfect_uniform():
     single_gate_duration = 5e3
     two_qubit_instructions = [INSTR_CNOT, INSTR_CZ]
     two_gate_duration = 2e5
+    all_qubit_instructions = [INSTR_ROT_X_ALL, INSTR_ROT_Y_ALL, INSTR_ROT_Z_ALL]
+    all_qubit_duration = 1e5
     topology = LhiTopologyBuilder.perfect_uniform(
         num_qubits,
         single_qubit_instructions,
         single_gate_duration,
         two_qubit_instructions,
         two_gate_duration,
+        all_qubit_instructions,
+        all_qubit_duration,
     )
 
     assert topology.qubit_infos == {
@@ -297,6 +329,16 @@ def test_perfect_uniform():
         if i != j
     }
 
+    assert topology.all_qubit_gate_infos == [
+        LhiGateInfo(
+            instruction=instr,
+            duration=all_qubit_duration,
+            error_model=DepolarNoiseModel,
+            error_model_kwargs={"depolar_rate": 0},
+        )
+        for instr in all_qubit_instructions
+    ]
+
 
 def test_build_fully_uniform():
     qubit_info = LhiQubitInfo(
@@ -327,11 +369,25 @@ def test_build_fully_uniform():
             },
         )
     ]
+
+    all_qubit_gate_infos = [
+        LhiGateInfo(
+            instruction=INSTR_ROT_X_ALL,
+            duration=1e4,
+            error_model=DepolarNoiseModel,
+            error_model_kwargs={
+                "depolar_rate": 0.2,
+                "time_independent": True,
+            },
+        )
+    ]
+
     topology = LhiTopologyBuilder.fully_uniform(
         num_qubits=3,
         qubit_info=qubit_info,
         single_gate_infos=single_gate_infos,
         two_gate_infos=two_gate_infos,
+        all_qubit_gate_infos=all_qubit_gate_infos,
     )
 
     assert len(topology.qubit_infos) == 3
@@ -349,6 +405,10 @@ def test_build_fully_uniform():
             multi = MultiQubit([i, j])
             gates = [info.instruction for info in topology.multi_gate_infos[multi]]
             assert INSTR_CNOT in gates
+
+    assert [INSTR_ROT_X_ALL] == [
+        info.instruction for info in topology.all_qubit_gate_infos
+    ]
 
 
 def test_perfect_star():
@@ -449,6 +509,66 @@ def test_generic_t1t2_star():
         )
 
 
+def test_trapped_ion_default_perfect_gates():
+    num_qubits = 3
+
+    topology = LhiTopologyBuilder.trapped_ion_default_perfect_gates(num_qubits)
+
+    single_qubit_instructions = [
+        INSTR_INIT,
+        INSTR_ROT_Z,
+        INSTR_MEASURE,
+        INSTR_MEASURE_INSTANT,
+    ]
+
+    assert topology.qubit_infos == {
+        i: LhiQubitInfo(
+            is_communication=True,
+            error_model=T1T2NoiseModel,
+            error_model_kwargs={"T1": 0, "T2": 0},
+        )
+        for i in range(num_qubits)
+    }
+
+    assert topology.single_gate_infos == {
+        i: [
+            LhiGateInfo(
+                instruction=instr,
+                duration=5e3,
+                error_model=DepolarNoiseModel,
+                error_model_kwargs={"depolar_rate": 0},
+            )
+            for instr in single_qubit_instructions
+        ]
+        for i in range(num_qubits)
+    }
+
+    assert topology.multi_gate_infos == {
+        MultiQubit([i, j]): []
+        for i in range(num_qubits)
+        for j in range(num_qubits)
+        if i != j
+    }
+
+    all_qubit_instructions = [
+        INSTR_INIT,
+        INSTR_MEASURE_ALL,
+        INSTR_ROT_X_ALL,
+        INSTR_ROT_Y_ALL,
+        INSTR_ROT_Z_ALL,
+        INSTR_BICHROMATIC,
+    ]
+    assert topology.all_qubit_gate_infos == [
+        LhiGateInfo(
+            instruction=instr,
+            duration=5e3,
+            error_model=DepolarNoiseModel,
+            error_model_kwargs={"depolar_rate": 0},
+        )
+        for instr in all_qubit_instructions
+    ]
+
+
 def test_latencies_from_config():
     cfg = LatenciesConfig(
         host_instr_time=2,
@@ -507,6 +627,7 @@ if __name__ == "__main__":
     test_build_fully_uniform()
     test_perfect_star()
     test_generic_t1t2_star()
+    test_trapped_ion_default_perfect_gates()
     test_latencies_from_config()
     test_link_from_config()
     test_link_from_config_2()

--- a/tests/test_lhi_to_ehi.py
+++ b/tests/test_lhi_to_ehi.py
@@ -133,6 +133,7 @@ def test_topology_to_ehi_trapped_ion():
     assert ehi.latencies.qnos_instr_time == 3
     assert ehi.latencies.host_peer_latency == 4
 
+
 def test_qubit_to_ehi():
     lhi_qubit = LhiTopologyBuilder.t1t2_qubit(is_communication=False, t1=3, t2=4)
     ehi_qubit = LhiConverter.qubit_info_to_ehi(lhi_qubit)

--- a/tests/test_measure_all.iqoala
+++ b/tests/test_measure_all.iqoala
@@ -1,0 +1,22 @@
+META_START
+    name: bob
+    parameters:
+    csockets: 0 -> alice
+    epr_sockets: 0 -> alice
+META_END
+
+^blk_host0 {type = QL}:
+    tuple<m0; m1; m2> = run_subroutine(tuple<>) : subrt1
+
+
+SUBROUTINE subrt1
+    params:
+    returns: m0, m1, m2
+    uses: 0, 1, 2
+    keeps:
+    request:
+  NETQASM_START
+    init_all
+    set Q0 0
+    meas_all Q0 @output
+  NETQASM_END

--- a/tests/test_qdevice.py
+++ b/tests/test_qdevice.py
@@ -19,6 +19,13 @@ from netsquid.components.qprocessor import MissingInstructionError
 from netsquid.nodes import Node
 from netsquid.qubits import ketstates
 
+from qoala.runtime.instructions import (
+    INSTR_BICHROMATIC,
+    INSTR_MEASURE_ALL,
+    INSTR_ROT_X_ALL,
+    INSTR_ROT_Y_ALL,
+    INSTR_ROT_Z_ALL,
+)
 from qoala.runtime.lhi import LhiTopologyBuilder
 from qoala.sim.build import build_qprocessor_from_topology
 from qoala.sim.qdevice import (
@@ -44,10 +51,20 @@ def perfect_uniform_qdevice(num_qubits: int) -> QDevice:
             INSTR_ROT_Y,
             INSTR_ROT_Z,
             INSTR_MEASURE,
+            INSTR_MEASURE_ALL,
         ],
         single_duration=5e3,
         two_instructions=[INSTR_CNOT],
         two_duration=100e3,
+        all_qubit_instructions=[
+            INSTR_INIT,
+            INSTR_MEASURE_ALL,
+            INSTR_ROT_X_ALL,
+            INSTR_ROT_Y_ALL,
+            INSTR_ROT_Z_ALL,
+            INSTR_BICHROMATIC,
+        ],
+        all_qubit_duration=100e3,
     )
     processor = build_qprocessor_from_topology(name="processor", topology=topology)
     node = Node(name="alice", qmemory=processor)
@@ -567,23 +584,149 @@ def test_non_initalized():
         netsquid_run(qdevice.execute_commands(commands))
 
 
-def test_multiple_measurement():
+def test_all_qubit_gates():
+    num_qubits = 3
+    qdevice = perfect_uniform_qdevice(num_qubits)
+
+    with pytest.raises(UnsupportedQDeviceCommandError):
+        commands = [QDeviceCommand(ns_instr.INSTR_X)]
+        netsquid_run(qdevice.execute_commands(commands))
+
+    with pytest.raises(UnsupportedQDeviceCommandError):
+        commands = [QDeviceCommand(INSTR_ROT_X_ALL, [0], angle=PI)]
+        netsquid_run(qdevice.execute_commands(commands))
+
+    with pytest.raises(UnsupportedQDeviceCommandError):
+        # All qubit commands should not have qubit indices.
+        commands = [QDeviceCommand(INSTR_ROT_X_ALL, [0, 1, 2], angle=PI)]
+        netsquid_run(qdevice.execute_commands(commands))
+
+
+def test_initialize_all():
     num_qubits = 3
     qdevice = perfect_uniform_qdevice(num_qubits)
 
     commands = [
-        QDeviceCommand(ns_instr.INSTR_INIT, [0]),
-        QDeviceCommand(ns_instr.INSTR_INIT, [1]),
-        QDeviceCommand(ns_instr.INSTR_INIT, [2]),
-        QDeviceCommand(ns_instr.INSTR_MEASURE, [0], output_key="m0"),
-        QDeviceCommand(ns_instr.INSTR_MEASURE, [1], output_key="m1"),
-        QDeviceCommand(ns_instr.INSTR_MEASURE, [2], output_key="m2"),
+        QDeviceCommand(
+            INSTR_INIT,
+        )
+    ]
+
+    netsquid_run(qdevice.execute_commands(commands))
+    ns.sim_run()
+
+    q0 = qdevice.get_local_qubit(0)
+    q1 = qdevice.get_local_qubit(1)
+    q2 = qdevice.get_local_qubit(2)
+    assert q0 is not None
+    assert q1 is not None
+    assert q2 is not None
+
+
+def test_measure_all():
+    num_qubits = 3
+    qdevice = perfect_uniform_qdevice(num_qubits)
+
+    commands = [
+        QDeviceCommand(
+            INSTR_INIT,
+        ),
+        QDeviceCommand(INSTR_Y, [1]),
+        QDeviceCommand(
+            INSTR_MEASURE_ALL,
+        ),
     ]
 
     meas_outcome = netsquid_run(qdevice.execute_commands(commands))
-    assert meas_outcome["m0"] == [0]
-    assert meas_outcome["m1"] == [0]
-    assert meas_outcome["m2"] == [0]
+    ns.sim_run()
+
+    q0 = qdevice.get_local_qubit(0)
+    q1 = qdevice.get_local_qubit(1)
+    q2 = qdevice.get_local_qubit(2)
+    assert has_state(q0, ketstates.s0)
+    assert has_state(q1, ketstates.s1)
+    assert has_state(q2, ketstates.s0)
+
+    assert meas_outcome == [0, 1, 0]
+
+
+def test_rotate_all():
+    num_qubits = 3
+    qdevice = perfect_uniform_qdevice(num_qubits)
+
+    commands = [
+        QDeviceCommand(
+            INSTR_INIT,
+        ),
+        QDeviceCommand(INSTR_ROT_X_ALL, angle=PI),
+    ]
+
+    netsquid_run(qdevice.execute_commands(commands))
+    ns.sim_run()
+
+    q0 = qdevice.get_local_qubit(0)
+    q1 = qdevice.get_local_qubit(1)
+    q2 = qdevice.get_local_qubit(2)
+    assert has_state(q0, ketstates.s1)
+    assert has_state(q1, ketstates.s1)
+    assert has_state(q2, ketstates.s1)
+
+    commands = [
+        QDeviceCommand(
+            INSTR_INIT,
+        ),
+        QDeviceCommand(INSTR_ROT_Y_ALL, angle=PI_OVER_2),
+    ]
+
+    netsquid_run(qdevice.execute_commands(commands))
+    ns.sim_run()
+
+    q0 = qdevice.get_local_qubit(0)
+    q1 = qdevice.get_local_qubit(1)
+    q2 = qdevice.get_local_qubit(2)
+    assert has_state(q0, ketstates.h0)
+    assert has_state(q1, ketstates.h0)
+    assert has_state(q2, ketstates.h0)
+
+    commands = [
+        QDeviceCommand(
+            INSTR_INIT,
+        ),
+        QDeviceCommand(INSTR_ROT_Y_ALL, angle=PI_OVER_2),
+        QDeviceCommand(INSTR_ROT_Z_ALL, angle=PI_OVER_2),
+    ]
+
+    netsquid_run(qdevice.execute_commands(commands))
+    ns.sim_run()
+
+    q0 = qdevice.get_local_qubit(0)
+    q1 = qdevice.get_local_qubit(1)
+    q2 = qdevice.get_local_qubit(2)
+    assert has_state(q0, ketstates.y0)
+    assert has_state(q1, ketstates.y0)
+    assert has_state(q2, ketstates.y0)
+
+
+def test_bichromatic():
+    num_qubits = 3
+    qdevice = perfect_uniform_qdevice(num_qubits)
+
+    commands = [
+        QDeviceCommand(
+            INSTR_INIT,
+        ),
+        QDeviceCommand(INSTR_ROT_X_ALL, angle=PI),
+    ]
+
+    netsquid_run(qdevice.execute_commands(commands))
+    ns.sim_run()
+
+    q0 = qdevice.get_local_qubit(0)
+    q1 = qdevice.get_local_qubit(1)
+    q2 = qdevice.get_local_qubit(2)
+    assert q0 is not None
+    assert q1 is not None
+    assert q2 is not None
 
 
 if __name__ == "__main__":
@@ -600,4 +743,8 @@ if __name__ == "__main__":
     test_unsupported_commands_generic()
     test_unsupported_commands_nv()
     test_non_initalized()
-    test_multiple_measurement()
+    test_all_qubit_gates()
+    test_initialize_all()
+    test_measure_all()
+    test_rotate_all()
+    test_bichromatic()

--- a/tests/test_qdevice.py
+++ b/tests/test_qdevice.py
@@ -567,6 +567,25 @@ def test_non_initalized():
         netsquid_run(qdevice.execute_commands(commands))
 
 
+def test_multiple_measurement():
+    num_qubits = 3
+    qdevice = perfect_uniform_qdevice(num_qubits)
+
+    commands = [
+        QDeviceCommand(ns_instr.INSTR_INIT, [0]),
+        QDeviceCommand(ns_instr.INSTR_INIT, [1]),
+        QDeviceCommand(ns_instr.INSTR_INIT, [2]),
+        QDeviceCommand(ns_instr.INSTR_MEASURE, [0], output_key="m0"),
+        QDeviceCommand(ns_instr.INSTR_MEASURE, [1], output_key="m1"),
+        QDeviceCommand(ns_instr.INSTR_MEASURE, [2], output_key="m2"),
+    ]
+
+    meas_outcome = netsquid_run(qdevice.execute_commands(commands))
+    assert meas_outcome["m0"] == [0]
+    assert meas_outcome["m1"] == [0]
+    assert meas_outcome["m2"] == [0]
+
+
 if __name__ == "__main__":
     test_static_generic()
     test_static_nv()
@@ -581,3 +600,4 @@ if __name__ == "__main__":
     test_unsupported_commands_generic()
     test_unsupported_commands_nv()
     test_non_initalized()
+    test_multiple_measurement()

--- a/tests/test_qdevice.py
+++ b/tests/test_qdevice.py
@@ -732,6 +732,8 @@ def test_bichromatic():
     assert q0 is not None
     assert q1 is not None
     assert q2 is not None
+
+
 def test_is_allowed():
     num_qubits = 3
     qdevice_gen = perfect_uniform_qdevice(num_qubits)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -103,7 +103,6 @@ def load_program_trapped_ion(path: str) -> QoalaProgram:
     return QoalaParser(text, flavour=TrappedIonFlavour()).parse()
 
 
-def setup_network() -> ProcNodeNetwork:
 def setup_network(internal_sched_latency: float = 0) -> ProcNodeNetwork:
     topology = LhiTopologyBuilder.perfect_uniform_default_gates(num_qubits=3)
     latencies = LhiLatencies(
@@ -1025,11 +1024,18 @@ def test_measure_all():
     pid = 0
     inputs_alice = ProgramInput({"bob_id": 1})
     instance_alice = instantiate(program_alice, alice.local_ehi, pid, inputs_alice)
+
+    alice.scheduler.submit_program_instance(instance_alice, 0)
+
+    ns.sim_reset()
+    assert ns.sim_time() == 0
+    network.start()
     ns.sim_run()
     alice_outcome = alice.memmgr.get_process(pid).host_mem.read("m0")
     alice_outcome2 = alice.memmgr.get_process(pid).host_mem.read("m1")
     alice_outcome3 = alice.memmgr.get_process(pid).host_mem.read("m2")
     assert alice_outcome == alice_outcome2 == alice_outcome3 == 0
+
 
 def test_internal_sched_latency():
     network = setup_network(internal_sched_latency=500)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1034,7 +1034,6 @@ def test_measure_all():
     assert alice_outcome == alice_outcome2 == alice_outcome3 == 0
 
 
-
 if __name__ == "__main__":
     test_cpu_scheduler()
     test_cpu_scheduler_no_time()


### PR DESCRIPTION
- `all qubit gate` options are added into `LHI`, `EHI`, `Config` and `build`.
- Convenience methods for building `EHI` and `LHI` topologies are modified accordingly.
- `Ion Trap NTF`
- Custom `NetSquid` instructions for all qubit gates.
- `QnosProcessor` for trapped ion.
- All qubit operations do not need to specify `indices` for `QDeviceCommand`.
- Tests are added.