### PR TITLE
Fixed multipair create and keep task execution bug

### DIFF
--- a/qoala/sim/netstack/netstackprocessor.py
+++ b/qoala/sim/netstack/netstackprocessor.py
@@ -123,6 +123,8 @@ class NetstackProcessor:
             self._interface.send_entdist_msg(Message(-1, -1, entdist_req))
 
         has_failed = False
+        # In case of failure we need to keep track of which qubits still need to be freed
+        qubit_freed_status = [False] * num_pairs
         for i, virt_id in enumerate(virt_ids):
             result_msg = yield from self._interface.receive_entdist_msg()
             self._logger.info(f"got result {result_msg}")
@@ -140,6 +142,21 @@ class NetstackProcessor:
                 # Free the qubit associated with the request
                 self._logger.info(f"freeing qubit {virt_id}")
                 self._interface.memmgr.free(process.pid, virt_id)
+
+                # Record that the virtual qubit at index i has been freed
+                qubit_freed_status[i] = True
+
+        # If one or more pairs fail, the entanglement gen task fails
+        # we need to make sure all of the pairs are freed
+        if has_failed:
+            for i, freed in enumerate(qubit_freed_status):
+                # This qubit needs to be freed
+                if not freed:
+                    virt_id = virt_ids[i]
+
+                    # Free the qubit associated with the request
+                    self._logger.info(f"freeing qubit {virt_id}")
+                    self._interface.memmgr.free(process.pid, virt_id)
 
         # Returns whether entanglement generation was successful
         return not has_failed


### PR DESCRIPTION
Fixed a bug where the multipair create and keep task would prematurely terminate, leaving rejection responses from the entanglement distributor in the message buffer.

The code has been rewritten so that when an entanglement request is rejected the memory associated with that request is freed, then the node waits for the response to the next request.